### PR TITLE
Added error message when the install task is used on a self-hosted agent

### DIFF
--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -13,6 +13,11 @@ async function run() {
 }
 
 async function install() {
+    const serverType = taskLib.getVariable("System.ServerType");
+    if (!serverType || serverType.toLowerCase() !== "hosted") {
+        throw new Error(taskLib.loc("InstallNotSupportedOnSelfHosted"));
+    }
+
     // download install bash script
     let scriptPath;
     try {

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -19,6 +19,7 @@
         }
     },
     "messages": {
+        "InstallNotSupportedOnSelfHosted": "The install task is not supported on self-hosted agents. Use the standard MATLAB installer to install MATLAB on this system.",
         "FailedToDownloadInstallScript": "Failed to download install script: %s",
         "FailedToExecuteInstallScript": "Failed to execute install script. Exited with code '%s'."
     }

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -19,7 +19,7 @@
         }
     },
     "messages": {
-        "InstallNotSupportedOnSelfHosted": "The install task is not supported on self-hosted agents. Use the standard MATLAB installer to install MATLAB on this system.",
+        "InstallNotSupportedOnSelfHosted": "Install MATLAB task is not supported on self-hosted agents. To install MATLAB on this machine, use the standard installer.",
         "FailedToDownloadInstallScript": "Failed to download install script: %s",
         "FailedToExecuteInstallScript": "Failed to execute install script. Exited with code '%s'."
     }

--- a/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+process.env.SYSTEM_SERVERTYPE = "hosted";
+
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
         if (url !== "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh") {

--- a/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+process.env.SYSTEM_SERVERTYPE = "hosted";
+
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
         if (url !== "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh") {

--- a/tasks/install-matlab/v0/test/failExecute.ts
+++ b/tasks/install-matlab/v0/test/failExecute.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+process.env.SYSTEM_SERVERTYPE = "hosted";
+
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
         if (url !== "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh") {

--- a/tasks/install-matlab/v0/test/failSelfHosted.ts
+++ b/tasks/install-matlab/v0/test/failSelfHosted.ts
@@ -6,12 +6,6 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
-process.env.SYSTEM_SERVERTYPE = "hosted";
-
-tr.registerMock("azure-pipelines-tool-lib/tool", {
-    downloadTool() {
-        throw new Error("Download failed");
-    },
-});
+process.env.SYSTEM_SERVERTYPE = "self-hosted";
 
 tr.run();

--- a/tasks/install-matlab/v0/test/suite.ts
+++ b/tasks/install-matlab/v0/test/suite.ts
@@ -52,4 +52,16 @@ describe("InstallMATLAB V0 Suite", () => {
 
         done();
     });
+
+    it("should fail on self-hosted agents", (done) => {
+        const tp = path.join(__dirname, "failSelfHosted.js");
+        const tr = new mt.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.failed, "should have failed");
+        assert(tr.stdOutContained("InstallNotSupportedOnSelfHosted"), "should have failed to install");
+
+        done();
+    });
 });


### PR DESCRIPTION
Added an error message when `InstallMATLAB` is used on a self-hosted agent. This helps avoid the scenario where someone gets an ephemeral version of MATLAB on their machine without understanding how it differs from a traditional installation.