### PR TITLE
Added Windows agents to integ tests

### DIFF
--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -12,21 +12,39 @@ stages:
     displayName: Integration test
     jobs:
       - job: test_install
+        strategy:
+          matrix:
+            microsofthosted:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+            selfhosted:
+              poolName: vmssagentpool # scale set of Windows agents
+              vmImage: # blank for self-hosted
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
-          - script: |
+          - bash: |
               set -e
               matlab -batch version
               mex -h
             displayName: Check matlab and mex
 
       - job: test_run_command
+        strategy:
+          matrix:
+            microsofthosted:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+            selfhosted:
+              poolName: vmssagentpool # scale set of Windows agents
+              vmImage: # blank for self-hosted
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
@@ -53,13 +71,22 @@ stages:
               command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b));
 
       - job: test_run_tests
+        strategy:
+          matrix:
+            microsofthosted:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+            selfhosted:
+              poolName: vmssagentpool # scale set of Windows agents
+              vmImage: # blank for self-hosted
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
-          - script: |
+          - bash: |
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m
               mkdir tests
@@ -75,11 +102,11 @@ stages:
               testResultsJUnit: test-results/matlab/results.xml
               codeCoverageCobertura: code-coverage/coverage.xml
               sourceFolder: src
-          - script: |
+          - bash: |
               set -e
               grep -q FirstTest test-results/matlab/results.xml
             displayName: Verify test results file was created
-          - script: |
+          - bash: |
               set -e
               grep -q add code-coverage/coverage.xml
             displayName: Verify code coverage file was created

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -5,6 +5,7 @@ resources:
       trigger: true
 
 trigger: none
+pr: none
 
 stages:
   - stage: integration_test

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -4,7 +4,7 @@ resources:
       source: pre-integ-test
       trigger:
         branches:
-          - *
+          - '*'
 
 trigger: none
 pr: none

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -44,7 +44,8 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - script: choco install wsl-ubuntu-1804 -y
+          - script: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
+            displayName: Add bash to path
             condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
@@ -84,7 +85,8 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - script: choco install wsl-ubuntu-1804 -y
+          - script: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
+            displayName: Add bash to path
             condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -44,9 +44,6 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - powershell: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
-            displayName: Add bash to path
-            condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
             condition: eq(variables['Agent.OS'], 'Linux')
@@ -85,9 +82,6 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - powershell: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
-            displayName: Add bash to path
-            condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
             condition: eq(variables['Agent.OS'], 'Linux')

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -44,6 +44,8 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
+          - script: choco install wsl-ubuntu-1804 -y
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
             condition: eq(variables['Agent.OS'], 'Linux')
@@ -82,6 +84,8 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
+          - script: choco install wsl-ubuntu-1804 -y
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
             condition: eq(variables['Agent.OS'], 'Linux')

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -17,9 +17,6 @@ stages:
             microsofthosted:
               poolName: Azure Pipelines
               vmImage: ubuntu-16.04
-            selfhosted:
-              poolName: vmssagentpool # scale set of Windows agents
-              vmImage: # blank for self-hosted
         pool:
           name: $(poolName)
           vmImage: $(vmImage)
@@ -49,6 +46,7 @@ stages:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
+            condition: eq(variables['Agent.OS'], 'Linux')
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run MATLAB statement
             inputs:
@@ -86,6 +84,7 @@ stages:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
+            condition: eq(variables['Agent.OS'], 'Linux')
           - bash: |
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -44,7 +44,7 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - script: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
+          - powershell: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
             displayName: Add bash to path
             condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
@@ -85,7 +85,7 @@ stages:
           vmImage: $(vmImage)
         steps:
           - checkout: none
-          - script: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
+          - powershell: Write-Host '##vso[task.prependpath]C:\Program Files\Git\bin'
             displayName: Add bash to path
             condition: eq(variables['Agent.OS'], 'Windows_NT')
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -2,7 +2,6 @@ resources:
   pipelines:
     - pipeline: integ_test_promote
       source: pre-integ-test
-      trigger: true
 
 trigger: none
 pr: none

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -5,7 +5,6 @@ resources:
       trigger: true
 
 trigger: none
-pr: none
 
 stages:
   - stage: integration_test

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -2,6 +2,9 @@ resources:
   pipelines:
     - pipeline: integ_test_promote
       source: pre-integ-test
+      trigger:
+        branches:
+          - *
 
 trigger: none
 pr: none

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -4,7 +4,7 @@ resources:
       source: build-test-publish
       trigger:
         branches:
-          - *
+          - '*'
 
 trigger: none
 pr: none

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -2,7 +2,6 @@ resources:
   pipelines:
     - pipeline: pre_integ_test
       source: build-test-publish
-      trigger: true
 
 trigger: none
 pr: none

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -5,7 +5,6 @@ resources:
       trigger: true
 
 trigger: none
-pr: none
 
 pool:
   vmImage: ubuntu-16.04

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -5,6 +5,7 @@ resources:
       trigger: true
 
 trigger: none
+pr: none
 
 pool:
   vmImage: ubuntu-16.04

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -2,6 +2,9 @@ resources:
   pipelines:
     - pipeline: pre_integ_test
       source: build-test-publish
+      trigger:
+        branches:
+          - *
 
 trigger: none
 pr: none


### PR DESCRIPTION
This change adds Windows agents when running the integ tests on Azure.

The Windows agents are part of an [Azure virtual machine scale set](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops). They boot up on Azure to perform the integ tests and then shutdown when the tests are done so we do not have to keep paying for them when they are idle.