### PR TITLE
Run command from script rather than command line

### DIFF
--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -12,25 +12,41 @@ stages:
     displayName: Integration test
     jobs:
       - job: test_install
+        strategy:
+          matrix:
+            microsoft_hosted_linux:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
-          - script: |
+          - bash: |
               set -e
               matlab -batch version
               mex -h
             displayName: Check matlab and mex
 
       - job: test_run_command
+        strategy:
+          matrix:
+            microsoft_hosted_linux:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+            self_hosted_windows:
+              poolName: vmssagentpool
+              vmImage: # blank for self-hosted
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
+            condition: not(startsWith(variables['Agent.Name'], 'vmss')) # InstallMATLAB on Microsoft-hosted agents only
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run MATLAB statement
             inputs:
@@ -53,13 +69,23 @@ stages:
               command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b));
 
       - job: test_run_tests
+        strategy:
+          matrix:
+            microsoft_hosted_linux:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+            self_hosted_windows:
+              poolName: vmssagentpool
+              vmImage: # blank for self-hosted
         pool:
-          vmImage: ubuntu-16.04
+          name: $(poolName)
+          vmImage: $(vmImage)
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
-          - script: |
+            condition: not(startsWith(variables['Agent.Name'], 'vmss')) # InstallMATLAB on Microsoft-hosted agents only
+          - bash: |
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m
               mkdir tests
@@ -75,11 +101,11 @@ stages:
               testResultsJUnit: test-results/matlab/results.xml
               codeCoverageCobertura: code-coverage/coverage.xml
               sourceFolder: src
-          - script: |
+          - bash: |
               set -e
               grep -q FirstTest test-results/matlab/results.xml
             displayName: Verify test results file was created
-          - script: |
+          - bash: |
               set -e
               grep -q add code-coverage/coverage.xml
             displayName: Verify code coverage file was created

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -71,6 +71,10 @@ stages:
             displayName: Run MATLAB statement with symbols
             inputs:
               command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
+            displayName: Run MATLAB statement in working directory
+            inputs:
+              command: exp = getenv('SYSTEM_DEFAULTWORKINGDIRECTORY'); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
 
       - job: test_run_tests
         strategy:

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -45,8 +45,8 @@ stages:
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
-            displayName: Install MATLAB
-            condition: not(startsWith(variables['Agent.Name'], 'vmss')) # InstallMATLAB on Microsoft-hosted agents only
+            displayName: Install MATLAB on Microsoft-hosted agents
+            condition: not(startsWith(variables['Agent.Name'], 'vmss'))
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run MATLAB statement
             inputs:
@@ -67,6 +67,10 @@ stages:
             displayName: Run MATLAB statement with quotes 3
             inputs:
               command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b));
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
+            displayName: Run MATLAB statement with all symbols
+            inputs:
+              command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\\\`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
 
       - job: test_run_tests
         strategy:
@@ -83,8 +87,8 @@ stages:
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
-            displayName: Install MATLAB
-            condition: not(startsWith(variables['Agent.Name'], 'vmss')) # InstallMATLAB on Microsoft-hosted agents only
+            displayName: Install MATLAB on Microsoft-hosted agents
+            condition: not(startsWith(variables['Agent.Name'], 'vmss'))
           - bash: |
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -68,7 +68,7 @@ stages:
             inputs:
               command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b));
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
-            displayName: Run MATLAB statement with all symbols
+            displayName: Run MATLAB statement with symbols
             inputs:
               command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\\\`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
 

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -70,7 +70,7 @@ stages:
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run MATLAB statement with symbols
             inputs:
-              command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\\\`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
+              command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
 
       - job: test_run_tests
         strategy:

--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -2,10 +2,12 @@
 
 import * as taskLib from "azure-pipelines-task-lib/task";
 import * as toolLib from "azure-pipelines-tool-lib/tool";
+import * as path from "path";
 import {platform} from "./utils";
 
 async function run() {
     try {
+        taskLib.setResourcePath(path.join( __dirname, "task.json"));
         await install();
     } catch (err) {
         taskLib.setResult(taskLib.TaskResult.Failed, err.message);

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -19,21 +19,21 @@ async function run() {
 async function runCommand(command: string) {
     // write command to script
     taskLib.assertAgent("2.115.0");
-    const workingDirectory = taskLib.getVariable("System.DefaultWorkingDirectory");
+    const workingDirectory = taskLib.getVariable("System.DefaultWorkingDirectory") || "";
     const tempDirectory = taskLib.getVariable("agent.tempDirectory") || "";
     taskLib.checkPath(tempDirectory, `${tempDirectory} (agent.tempDirectory)`);
     const scriptName = "command_" + uuidV4().replace(/-/g, "_");
     const scriptPath = path.join(tempDirectory, scriptName + ".m");
     await fs.writeFileSync(
         scriptPath,
-        "cd('" + workingDirectory + "');\n" + command,
+        "cd('" + workingDirectory.replace(/'/g, "''") + "');\n" + command,
         { encoding: "utf8" });
 
     // run script
     const runToolPath = path.join(__dirname, "bin", "run_matlab_command." + (platform() === "win32" ? "bat" : "sh"));
     chmodSync(runToolPath, "777");
     const runTool = taskLib.tool(runToolPath);
-    runTool.arg("cd('" + tempDirectory + "'); " + scriptName);
+    runTool.arg("cd('" + tempDirectory.replace(/'/g, "''") + "'); " + scriptName);
     const exitCode = await runTool.exec();
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToRunCommand"));

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -18,6 +18,7 @@ async function run() {
 
 async function runCommand(command: string) {
     // write command to script
+    console.log(taskLib.loc("GeneratingScript", command));
     taskLib.assertAgent("2.115.0");
     const workingDirectory = taskLib.getVariable("System.DefaultWorkingDirectory") || "";
     const tempDirectory = taskLib.getVariable("agent.tempDirectory") || "";
@@ -30,6 +31,7 @@ async function runCommand(command: string) {
         { encoding: "utf8" });
 
     // run script
+    console.log("========================== Starting Command Output ===========================");
     const runToolPath = path.join(__dirname, "bin", "run_matlab_command." + (platform() === "win32" ? "bat" : "sh"));
     chmodSync(runToolPath, "777");
     const runTool = taskLib.tool(runToolPath);

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -22,7 +22,7 @@ async function runCommand(command: string) {
     const workingDirectory = taskLib.getVariable("System.DefaultWorkingDirectory");
     const tempDirectory = taskLib.getVariable("agent.tempDirectory") || "";
     taskLib.checkPath(tempDirectory, `${tempDirectory} (agent.tempDirectory)`);
-    const scriptName = "cmd_" + uuidV4().replace(/-/g, "_");
+    const scriptName = "command_" + uuidV4().replace(/-/g, "_");
     const scriptPath = path.join(tempDirectory, scriptName + ".m");
     await fs.writeFileSync(
         scriptPath,

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -1,6 +1,7 @@
 // Copyright 2020 The MathWorks, Inc.
 
 import * as taskLib from "azure-pipelines-task-lib/task";
+import * as toolRunner from "azure-pipelines-task-lib/toolrunner";
 import { chmodSync } from "fs";
 import * as fs from "fs";
 import * as path from "path";
@@ -36,8 +37,10 @@ async function runCommand(command: string) {
     const runToolPath = path.join(__dirname, "bin", "run_matlab_command." + (platform() === "win32" ? "bat" : "sh"));
     chmodSync(runToolPath, "777");
     const runTool = taskLib.tool(runToolPath);
-    runTool.arg("cd('" + tempDirectory.replace(/'/g, "''") + "'); " + scriptName);
-    const exitCode = await runTool.exec();
+    runTool.arg(scriptName);
+    const exitCode = await runTool.exec({
+        cwd: tempDirectory,
+    } as toolRunner.IExecOptions);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToRunCommand"));
     }

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -9,6 +9,7 @@ import {platform} from "./utils";
 
 async function run() {
     try {
+        taskLib.setResourcePath(path.join( __dirname, "task.json"));
         const command = taskLib.getInput("command", true);
         await runCommand(command as string);
     } catch (err) {

--- a/tasks/run-matlab-command/v0/task.json
+++ b/tasks/run-matlab-command/v0/task.json
@@ -29,6 +29,7 @@
         }
     },
     "messages": {
+        "GeneratingScript": "Generating MATLAB script with content:\n%s",
         "FailedToRunCommand": "Failed to run command successfully."
     }
 }

--- a/tasks/run-matlab-command/v0/test/failRunCommand.ts
+++ b/tasks/run-matlab-command/v0/test/failRunCommand.ts
@@ -13,18 +13,52 @@ tr.registerMock("./utils", {
     platform: () => "linux",
 });
 
+// create assertAgent and getVariable mocks, support not added in this version of task-lib
+import tl = require("azure-pipelines-task-lib/mock-task");
+const tlClone = Object.assign({}, tl);
+// @ts-ignore
+tlClone.getVariable = (variable: string) => {
+    if (variable.toLowerCase() === "agent.tempdirectory") {
+        return "temp/path";
+    }
+    if (variable.toLowerCase() === "system.defaultworkingdirectory") {
+        return "work/dir";
+    }
+    return null;
+};
+// @ts-ignore
+tlClone.assertAgent = (variable: string) => {
+    return;
+};
+tr.registerMock("azure-pipelines-task-lib/mock-task", tlClone);
+
 const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_command.sh");
 const a: ma.TaskLibAnswers = {
     checkPath: {
         [runCmdPath]: true,
+        "temp/path": true,
     },
     exec: {
-        [runCmdPath + " myscript"]: {
+        [runCmdPath + " cd('temp/path'); cmd_1_2_3"]: {
             code: 1,
             stdout: "BAM!",
         },
     },
 } as ma.TaskLibAnswers;
 tr.setAnswers(a);
+
+// mock fs
+import fs = require("fs");
+const fsClone = Object.assign({}, fs);
+fsClone.writeFileSync = (filePath: string, contents: any, options: any) => {
+    // tslint:disable-next-line:no-console
+    console.log(`writing ${contents} to ${filePath}`);
+};
+tr.registerMock("fs", fsClone);
+
+// mock uuidv4
+tr.registerMock("uuid/v4", () => {
+    return "1-2-3";
+});
 
 tr.run();

--- a/tasks/run-matlab-command/v0/test/failRunCommand.ts
+++ b/tasks/run-matlab-command/v0/test/failRunCommand.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp/path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp/path'); command_1_2_3"]: {
+        [runCmdPath + " command_1_2_3"]: {
             code: 1,
             stdout: "BAM!",
         },

--- a/tasks/run-matlab-command/v0/test/failRunCommand.ts
+++ b/tasks/run-matlab-command/v0/test/failRunCommand.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp/path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp/path'); cmd_1_2_3"]: {
+        [runCmdPath + " cd('temp/path'); command_1_2_3"]: {
             code: 1,
             stdout: "BAM!",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandLinux.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandLinux.ts
@@ -13,18 +13,52 @@ tr.registerMock("./utils", {
     platform: () => "linux",
 });
 
+// create assertAgent and getVariable mocks, support not added in this version of task-lib
+import tl = require("azure-pipelines-task-lib/mock-task");
+const tlClone = Object.assign({}, tl);
+// @ts-ignore
+tlClone.getVariable = (variable: string) => {
+    if (variable.toLowerCase() === "agent.tempdirectory") {
+        return "temp/path";
+    }
+    if (variable.toLowerCase() === "system.defaultworkingdirectory") {
+        return "work/dir";
+    }
+    return null;
+};
+// @ts-ignore
+tlClone.assertAgent = (variable: string) => {
+    return;
+};
+tr.registerMock("azure-pipelines-task-lib/mock-task", tlClone);
+
 const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_command.sh");
 const a: ma.TaskLibAnswers = {
     checkPath: {
         [runCmdPath]: true,
+        "temp/path": true,
     },
     exec: {
-        [runCmdPath + " myscript"]: {
+        [runCmdPath + " cd('temp/path'); cmd_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },
     },
 } as ma.TaskLibAnswers;
 tr.setAnswers(a);
+
+// mock fs
+import fs = require("fs");
+const fsClone = Object.assign({}, fs);
+fsClone.writeFileSync = (filePath: string, contents: any, options: any) => {
+    // tslint:disable-next-line:no-console
+    console.log(`writing ${contents} to ${filePath}`);
+};
+tr.registerMock("fs", fsClone);
+
+// mock uuidv4
+tr.registerMock("uuid/v4", () => {
+    return "1-2-3";
+});
 
 tr.run();

--- a/tasks/run-matlab-command/v0/test/runCommandLinux.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandLinux.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp/path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp/path'); cmd_1_2_3"]: {
+        [runCmdPath + " cd('temp/path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandLinux.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandLinux.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp's/path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp''s/path'); command_1_2_3"]: {
+        [runCmdPath + " command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandLinux.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandLinux.ts
@@ -19,10 +19,10 @@ const tlClone = Object.assign({}, tl);
 // @ts-ignore
 tlClone.getVariable = (variable: string) => {
     if (variable.toLowerCase() === "agent.tempdirectory") {
-        return "temp/path";
+        return "temp's/path";
     }
     if (variable.toLowerCase() === "system.defaultworkingdirectory") {
-        return "work/dir";
+        return "work's/dir";
     }
     return null;
 };
@@ -36,10 +36,10 @@ const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_command
 const a: ma.TaskLibAnswers = {
     checkPath: {
         [runCmdPath]: true,
-        "temp/path": true,
+        "temp's/path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp/path'); command_1_2_3"]: {
+        [runCmdPath + " cd('temp''s/path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandWindows.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandWindows.ts
@@ -19,10 +19,10 @@ const tlClone = Object.assign({}, tl);
 // @ts-ignore
 tlClone.getVariable = (variable: string) => {
     if (variable.toLowerCase() === "agent.tempdirectory") {
-        return "temp\\path";
+        return "temp's\\path";
     }
     if (variable.toLowerCase() === "system.defaultworkingdirectory") {
-        return "work\\dir";
+        return "work's\\dir";
     }
     return null;
 };
@@ -36,10 +36,10 @@ const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_command
 const a: ma.TaskLibAnswers = {
     checkPath: {
         [runCmdPath]: true,
-        "temp\\path": true,
+        "temp's\\path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp\\path'); command_1_2_3"]: {
+        [runCmdPath + " cd('temp''s\\path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandWindows.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandWindows.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp\\path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp\\path'); cmd_1_2_3"]: {
+        [runCmdPath + " cd('temp\\path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandWindows.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandWindows.ts
@@ -13,18 +13,52 @@ tr.registerMock("./utils", {
     platform: () => "win32",
 });
 
+// create assertAgent and getVariable mocks, support not added in this version of task-lib
+import tl = require("azure-pipelines-task-lib/mock-task");
+const tlClone = Object.assign({}, tl);
+// @ts-ignore
+tlClone.getVariable = (variable: string) => {
+    if (variable.toLowerCase() === "agent.tempdirectory") {
+        return "temp\\path";
+    }
+    if (variable.toLowerCase() === "system.defaultworkingdirectory") {
+        return "work\\dir";
+    }
+    return null;
+};
+// @ts-ignore
+tlClone.assertAgent = (variable: string) => {
+    return;
+};
+tr.registerMock("azure-pipelines-task-lib/mock-task", tlClone);
+
 const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_command.bat");
 const a: ma.TaskLibAnswers = {
     checkPath: {
         [runCmdPath]: true,
+        "temp\\path": true,
     },
     exec: {
-        [runCmdPath + " myscript"]: {
+        [runCmdPath + " cd('temp\\path'); cmd_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },
     },
 } as ma.TaskLibAnswers;
 tr.setAnswers(a);
+
+// mock fs
+import fs = require("fs");
+const fsClone = Object.assign({}, fs);
+fsClone.writeFileSync = (filePath: string, contents: any, options: any) => {
+    // tslint:disable-next-line:no-console
+    console.log(`writing ${contents} to ${filePath}`);
+};
+tr.registerMock("fs", fsClone);
+
+// mock uuidv4
+tr.registerMock("uuid/v4", () => {
+    return "1-2-3";
+});
 
 tr.run();

--- a/tasks/run-matlab-command/v0/test/runCommandWindows.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandWindows.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp's\\path": true,
     },
     exec: {
-        [runCmdPath + " cd('temp''s\\path'); command_1_2_3"]: {
+        [runCmdPath + " command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-tests/v0/main.ts
+++ b/tasks/run-matlab-tests/v0/main.ts
@@ -7,6 +7,7 @@ import {platform} from "./utils";
 
 async function run() {
     try {
+        taskLib.setResourcePath(path.join( __dirname, "task.json"));
         const options: IRunTestsOptions = {
             JUnitTestResults: taskLib.getInput("testResultsJUnit"),
             CoberturaCodeCoverage: taskLib.getInput("codeCoverageCobertura"),

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,8 @@
     ],
     "jsRules": {},
     "rules": {
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "no-console": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
This change modifies `RunMATLABCommand` to write the command to a script and execute the script rather than passing the command directly to `run_matlab_command`. This approach helps avoid issues with the system shell interpreting the command before it gets to MATLAB.

The command is written to a script named `command_UUID.m` in an agent temp directory. A UUID is used in the script name to avoid having multiple jobs accidentally referring to the same cmd script as well as avoid polluting the MATLAB path with names the user may want to utilize. It further communicates to the user, who may see it in their stack, that the script is a temporary file. `-` characters in the UUID are replaced by `_` to adhere to MATLAB script naming restrictions.

Windows agents have also been added to the integ tests.