### PR TITLE
Fix for execution of startup.m in project root folder

### DIFF
--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -75,6 +75,12 @@ stages:
             displayName: Run MATLAB statement in working directory
             inputs:
               command: exp = getenv('SYSTEM_DEFAULTWORKINGDIRECTORY'); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
+          - bash: |
+              echo 'myvar = 123' > startup.m
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
+            displayName: MATLAB runs startup.m automatically
+            inputs:
+              command: assert(myvar == 123, 'myvar was not set as expected by startup.m')
 
       - job: test_run_tests
         strategy:
@@ -117,6 +123,12 @@ stages:
               set -e
               grep -q add code-coverage/coverage.xml
             displayName: Verify code coverage file was created
+          - bash: |
+              echo 'myvar = 123' > startup.m
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
+            displayName: MATLAB runs startup.m automatically
+            inputs:
+              command: assert(myvar == 123, 'myvar was not set as expected by startup.m')
 
   - stage: publish_prerelease
     displayName: Publish prerelease

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -77,10 +77,11 @@ stages:
               command: exp = getenv('SYSTEM_DEFAULTWORKINGDIRECTORY'); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
           - bash: |
               echo 'myvar = 123' > startup.m
+            displayName: Create startup.m
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: MATLAB runs startup.m automatically
             inputs:
-              command: assert(myvar == 123, 'myvar was not set as expected by startup.m')
+              command: assert(myvar==123, 'myvar was not set as expected by startup.m')
 
       - job: test_run_tests
         strategy:
@@ -100,10 +101,12 @@ stages:
             displayName: Install MATLAB on Microsoft-hosted agents
             condition: not(startsWith(variables['Agent.Name'], 'vmss'))
           - bash: |
+              echo 'myvar = 123' > startup.m
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m
               mkdir tests
-              printf "%%%% FirstTest\nassert(add(1,2)==3)" > tests/mytest.m
+              printf "%%%% StartupTest\nassert(myvar==123)" > tests/mytest.m
+              printf "%%%% FirstTest\nassert(add(1,2)==3)" >> tests/mytest.m
             displayName: Make MATLAB tests
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
             displayName: Run MATLAB tests with defaults
@@ -123,12 +126,6 @@ stages:
               set -e
               grep -q add code-coverage/coverage.xml
             displayName: Verify code coverage file was created
-          - bash: |
-              echo 'myvar = 123' > startup.m
-          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
-            displayName: MATLAB runs startup.m automatically
-            inputs:
-              command: assert(myvar == 123, 'myvar was not set as expected by startup.m')
 
   - stage: publish_prerelease
     displayName: Publish prerelease

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -105,8 +105,10 @@ stages:
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m
               mkdir tests
-              printf "%%%% StartupTest\nassert(myvar==123)" > tests/mytest.m
-              printf "%%%% FirstTest\nassert(add(1,2)==3)" >> tests/mytest.m
+              echo "%%%% StartupTest" > tests/mytest.m
+              echo "evalin('base','assert(myvar==123)')" >> tests/mytest.m
+              echo "%%%% FirstTest" >> tests/mytest.m
+              echo "assert(add(1,2)==3)" >> tests/mytest.m
             displayName: Make MATLAB tests
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
             displayName: Run MATLAB tests with defaults

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -105,9 +105,9 @@ stages:
               mkdir src
               echo 'function c=add(a,b);c=a+b;' > src/add.m
               mkdir tests
-              echo "%%%% StartupTest" > tests/mytest.m
+              echo "%% StartupTest" > tests/mytest.m
               echo "evalin('base','assert(myvar==123)')" >> tests/mytest.m
-              echo "%%%% FirstTest" >> tests/mytest.m
+              echo "%% FirstTest" >> tests/mytest.m
               echo "assert(add(1,2)==3)" >> tests/mytest.m
             displayName: Make MATLAB tests
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0

--- a/tasks/run-matlab-command/v0/main.ts
+++ b/tasks/run-matlab-command/v0/main.ts
@@ -1,7 +1,6 @@
 // Copyright 2020 The MathWorks, Inc.
 
 import * as taskLib from "azure-pipelines-task-lib/task";
-import * as toolRunner from "azure-pipelines-task-lib/toolrunner";
 import { chmodSync } from "fs";
 import * as fs from "fs";
 import * as path from "path";
@@ -37,10 +36,8 @@ async function runCommand(command: string) {
     const runToolPath = path.join(__dirname, "bin", "run_matlab_command." + (platform() === "win32" ? "bat" : "sh"));
     chmodSync(runToolPath, "777");
     const runTool = taskLib.tool(runToolPath);
-    runTool.arg(scriptName);
-    const exitCode = await runTool.exec({
-        cwd: tempDirectory,
-    } as toolRunner.IExecOptions);
+    runTool.arg("cd('" + tempDirectory.replace(/'/g, "''") + "'); " + scriptName);
+    const exitCode = await runTool.exec();
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToRunCommand"));
     }

--- a/tasks/run-matlab-command/v0/test/failRunCommand.ts
+++ b/tasks/run-matlab-command/v0/test/failRunCommand.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp/path": true,
     },
     exec: {
-        [runCmdPath + " command_1_2_3"]: {
+        [runCmdPath + ` cd('temp/path'); command_1_2_3`]: {
             code: 1,
             stdout: "BAM!",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandLinux.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandLinux.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp's/path": true,
     },
     exec: {
-        [runCmdPath + " command_1_2_3"]: {
+        [runCmdPath + " cd('temp''s/path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },

--- a/tasks/run-matlab-command/v0/test/runCommandWindows.ts
+++ b/tasks/run-matlab-command/v0/test/runCommandWindows.ts
@@ -39,7 +39,7 @@ const a: ma.TaskLibAnswers = {
         "temp's\\path": true,
     },
     exec: {
-        [runCmdPath + " command_1_2_3"]: {
+        [runCmdPath + " cd('temp''s\\path'); command_1_2_3"]: {
             code: 0,
             stdout: "hello world",
         },


### PR DESCRIPTION
This change ensures RunMATLABCommand opens MATLAB in the current working folder, rather than the temp folder, so that a `startup.m` file the user may have in their working folder is executed.

Unfortunately triggered pipelines don't show up in GitHub checks, so the integ test runs do not show up below. You can find them [here](https://dev.azure.com/iat-ci-dev/matlab-azure-devops-extension/_build/results?buildId=240&view=results).