### PR TITLE
Add release parameter to InstallMATLAB task

### DIFF
--- a/build-test-publish.pipeline.yml
+++ b/build-test-publish.pipeline.yml
@@ -1,4 +1,4 @@
-name: 0.1$(Rev:.r)
+name: 0.2$(Rev:.r)
 
 trigger:
   - master

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -30,6 +30,26 @@ stages:
               mex -h
             displayName: Check matlab and mex
 
+      - job: test_install_release
+        strategy:
+          matrix:
+            microsoft_hosted_linux:
+              poolName: Azure Pipelines
+              vmImage: ubuntu-16.04
+        pool:
+          name: $(poolName)
+          vmImage: $(vmImage)
+        steps:
+          - checkout: none
+          - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
+            displayName: Install MATLAB
+            inputs:
+              release: R2020a
+          - bash: |
+              set -e
+              matlab -batch "assert(strcmp(version('-release'),'2020a'))"
+            displayName: Check matlab release
+
       - job: test_run_command
         strategy:
           matrix:

--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -8,33 +8,35 @@ import {platform} from "./utils";
 async function run() {
     try {
         taskLib.setResourcePath(path.join( __dirname, "task.json"));
-        await install();
+        const release = taskLib.getInput("release", true);
+        await install(release as string);
     } catch (err) {
         taskLib.setResult(taskLib.TaskResult.Failed, err.message);
     }
 }
 
-async function install() {
+async function install(release: string) {
     const serverType = taskLib.getVariable("System.ServerType");
     if (!serverType || serverType.toLowerCase() !== "hosted") {
         throw new Error(taskLib.loc("InstallNotSupportedOnSelfHosted"));
     }
 
     // install core system dependencies
-    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh");
+    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", release);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
     }
 
     // install ephemeral version of MATLAB
-    exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh");
+    exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh",
+        ["--release", release]);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
     }
 }
 
 // similar to "curl | sh"
-async function curlsh(url: string) {
+async function curlsh(url: string, args: string | string[]) {
     // download script
     const scriptPath = await toolLib.downloadTool(url);
 
@@ -47,6 +49,7 @@ async function curlsh(url: string) {
         bash = taskLib.tool("sudo").arg("-E").line(bashPath);
     }
     bash.arg(scriptPath);
+    bash.arg(args);
     return bash.exec();
 }
 

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -12,6 +12,16 @@
         "Minor": 1,
         "Patch": 0
     },
+    "inputs": [
+        {
+            "name": "release",
+            "type": "string",
+            "label": "Release",
+            "required": true,
+            "defaultValue": "latest",
+            "helpMarkDown": "MATLAB release to install. The value specified should follow the MATLAB release naming convention (e.g. R2020a). The latest release will be installed by default. Releases R2020a and above are available shortly after their general release on MathWorks.com."
+        }
+    ],
     "instanceNameFormat": "Install MATLAB",
     "execution": {
         "Node10": {

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -3,7 +3,7 @@
     "id": "553fa7ff-af12-4821-8ace-6bf3dc410e62",
     "name": "InstallMATLAB",
     "friendlyName": "Install MATLAB",
-    "description": "Install the latest MATLAB release on a Linux-based Microsoft-hosted agent. Currently, this task is available only for public projects and does not include transformation products, such as MATLAB Coder and MATLAB Compiler.",
+    "description": "Install MATLAB on a Linux-based Microsoft-hosted agent. Currently, this task is available only for public projects and does not include transformation products, such as MATLAB Coder and MATLAB Compiler.",
     "helpMarkDown": "",
     "category": "Tool",
     "author": "The MathWorks, Inc.",

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -19,7 +19,7 @@
             "label": "Release",
             "required": true,
             "defaultValue": "latest",
-            "helpMarkDown": "MATLAB release to install. The value specified should follow the MATLAB release naming convention (e.g. R2020a). The latest release will be installed by default. Releases R2020a and above are available shortly after their general release on MathWorks.com."
+            "helpMarkDown": "MATLAB release to install. You can specify R2020a or a later release. By default, the task installs the latest release of MATLAB."
         }
     ],
     "instanceNameFormat": "Install MATLAB",

--- a/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+tr.setInput("release", "R2020a");
+
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
@@ -31,7 +33,11 @@ const a: ma.TaskLibAnswers = {
         "/bin/bash": true,
     },
     exec: {
-        "sudo -E /bin/bash install.sh": {
+        "sudo -E /bin/bash install.sh R2020a": {
+            code: 0,
+            stdout: "Installed MATLAB dependencies",
+        },
+        "sudo -E /bin/bash install.sh --release R2020a": {
             code: 0,
             stdout: "Installed MATLAB",
         },

--- a/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+tr.setInput("release", "R2020a");
+
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
@@ -31,7 +33,11 @@ const a: ma.TaskLibAnswers = {
         "bash.exe": true,
     },
     exec: {
-        "bash.exe install.sh": {
+        "bash.exe install.sh R2020a": {
+            code: 0,
+            stdout: "Installed MATLAB",
+        },
+        "bash.exe install.sh --release R2020a": {
             code: 0,
             stdout: "Installed MATLAB",
         },

--- a/tasks/install-matlab/v0/test/failDownload.ts
+++ b/tasks/install-matlab/v0/test/failDownload.ts
@@ -6,6 +6,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+tr.setInput("release", "R2020a");
+
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {

--- a/tasks/install-matlab/v0/test/failExecute.ts
+++ b/tasks/install-matlab/v0/test/failExecute.ts
@@ -7,6 +7,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+tr.setInput("release", "R2020a");
+
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
@@ -31,9 +33,9 @@ const a: ma.TaskLibAnswers = {
         "/bin/bash": true,
     },
     exec: {
-        "sudo -E /bin/bash install.sh": {
+        "sudo -E /bin/bash install.sh R2020a": {
             code: 1,
-            stdout: "Failed to install MATLAB",
+            stdout: "Failed to install MATLAB dependencies",
         },
     },
 } as ma.TaskLibAnswers;

--- a/tasks/install-matlab/v0/test/failSelfHosted.ts
+++ b/tasks/install-matlab/v0/test/failSelfHosted.ts
@@ -6,6 +6,8 @@ import path = require("path");
 const tp = path.join(__dirname, "..", "main.js");
 const tr = new mr.TaskMockRunner(tp);
 
+tr.setInput("release", "R2020a");
+
 process.env.SYSTEM_SERVERTYPE = "self-hosted";
 
 tr.run();


### PR DESCRIPTION
This change adds a `release` parameter to the `InstallMATLAB` task, where the user can specify the release of MATLAB to install:

```yaml
steps:
- task: InstallMATLAB@0
  inputs:
    release: R2020a
```