### PR TITLE
Update RunMATLABTests to use `Script.run`

### DIFF
--- a/tasks/run-matlab-tests/v0/main.ts
+++ b/tasks/run-matlab-tests/v0/main.ts
@@ -23,18 +23,14 @@ async function runTests(options: IRunTestsOptions) {
     chmodSync(runToolPath, "777");
     const runTool = taskLib.tool(runToolPath);
     runTool.arg(`addpath('${path.join(__dirname, "scriptgen")}');` +
-        `testScript = genscript('Test','WorkingFolder','..',` +
+        `testScript = genscript('Test',` +
             `'JUnitTestResults','${options.JUnitTestResults || ""}',` +
             `'CoberturaCodeCoverage','${options.CoberturaCodeCoverage || ""}',` +
             `'SourceFolder','${options.SourceFolder || ""}');` +
-        `scriptFolder = '.matlab';` +
-        `scriptPath = fullfile(scriptFolder, 'runAllTests.m');` +
-        `testScript.writeToFile(scriptPath);` +
-        `disp(['Running ''' scriptPath ''':']);` +
-        `type(scriptPath);` +
+        `disp('Running MATLAB script with contents:');` +
+        `disp(strtrim(testScript.writeToText()));` +
         `fprintf('__________\\n\\n');` +
-        `cd(scriptFolder);` +
-        `runAllTests;`);
+        `run(testScript);`);
     const exitCode = await runTool.exec();
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToRunTests"));

--- a/tasks/run-matlab-tests/v0/test/common.ts
+++ b/tasks/run-matlab-tests/v0/test/common.ts
@@ -6,16 +6,12 @@ export const runCmdPath = path.join(path.dirname(__dirname), "bin", "run_matlab_
 
 export function runCmdArg(junit: string, cobertura: string, source: string) {
     return "addpath('" + path.join(path.dirname(__dirname), "scriptgen") + "');" +
-        "testScript = genscript('Test','WorkingFolder','..'," +
+        "testScript = genscript('Test'," +
             "'JUnitTestResults','" + junit + "'," +
             "'CoberturaCodeCoverage','" + cobertura + "'," +
             "'SourceFolder','" + source + "');" +
-        `scriptFolder = '.matlab';` +
-        `scriptPath = fullfile(scriptFolder, 'runAllTests.m');` +
-        `testScript.writeToFile(scriptPath);` +
-        `disp(['Running ''' scriptPath ''':']);` +
-        `type(scriptPath);` +
+        `disp('Running MATLAB script with contents:');` +
+        `disp(strtrim(testScript.writeToText()));` +
         `fprintf('__________\\n\\n');` +
-        `cd(scriptFolder);` +
-        `runAllTests;`;
+        `run(testScript);`;
 }


### PR DESCRIPTION
This change simplifies the run-tests command implementation by using the `Script.run` method.