### PR TITLE
Move to mathworks-ci.com for all assets

### DIFF
--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -22,13 +22,13 @@ async function install(release: string) {
     }
 
     // install core system dependencies
-    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", release);
+    let exitCode = await curlsh("https://static.mathworks-ci.com/matlab-deps/v0/install.sh", release);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
     }
 
     // install ephemeral version of MATLAB
-    exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh",
+    exitCode = await curlsh("https://static.mathworks-ci.com/ephemeral-matlab/v0/ci-install.sh",
         ["--release", release]);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));

--- a/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
@@ -13,9 +13,9 @@ process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
-        if (url === "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh") {
+        if (url === "https://static.mathworks-ci.com/matlab-deps/v0/install.sh") {
             return "install.sh";
-        } else if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
+        } else if (url === "https://static.mathworks-ci.com/ephemeral-matlab/v0/ci-install.sh") {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");

--- a/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
@@ -13,9 +13,9 @@ process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
-        if (url === "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh") {
+        if (url === "https://static.mathworks-ci.com/matlab-deps/v0/install.sh") {
             return "install.sh";
-        } else if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
+        } else if (url === "https://static.mathworks-ci.com/ephemeral-matlab/v0/ci-install.sh") {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");

--- a/tasks/install-matlab/v0/test/failExecute.ts
+++ b/tasks/install-matlab/v0/test/failExecute.ts
@@ -13,9 +13,9 @@ process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
-        if (url === "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh") {
+        if (url === "https://static.mathworks-ci.com/matlab-deps/v0/install.sh") {
             return "install.sh";
-        } else if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
+        } else if (url === "https://static.mathworks-ci.com/ephemeral-matlab/v0/ci-install.sh") {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");

--- a/tasks/run-matlab-command/v0/package.json
+++ b/tasks/run-matlab-command/v0/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "postinstall": "npm run getBinDep",
-        "getBinDep": "wget -q https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip -O bin.zip; unzip -qod bin bin.zip; rm bin.zip"
+        "getBinDep": "wget -q https://static.mathworks-ci.com/run-matlab-command/v0/run-matlab-command.zip -O bin.zip; unzip -qod bin bin.zip; rm bin.zip"
     },
     "dependencies": {
         "@types/node": "^6.0.0",

--- a/tasks/run-matlab-tests/v0/package.json
+++ b/tasks/run-matlab-tests/v0/package.json
@@ -4,8 +4,8 @@
     "private": true,
     "scripts": {
         "postinstall": "npm run getBinDep && npm run getScriptgenDep",
-        "getBinDep": "wget -q https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip -O bin.zip; unzip -qod bin bin.zip; rm bin.zip",
-        "getScriptgenDep": "wget -q https://ssd.mathworks.com/supportfiles/ci/matlab-script-generator/v0/matlab-script-generator.zip -O scriptgen.zip; unzip -qod scriptgen scriptgen.zip; rm scriptgen.zip"
+        "getBinDep": "wget -q https://static.mathworks-ci.com/run-matlab-command/v0/run-matlab-command.zip -O bin.zip; unzip -qod bin bin.zip; rm bin.zip",
+        "getScriptgenDep": "wget -q https://static.mathworks-ci.com/matlab-script-generator/v0/matlab-script-generator.zip -O scriptgen.zip; unzip -qod scriptgen scriptgen.zip; rm scriptgen.zip"
     },
     "dependencies": {
         "@types/node": "^6.0.0",


### PR DESCRIPTION
This change switches all references of `ssd.mathworks.com` to `static.mathworks-ci.com`.