### PR TITLE
Updated doc with new selectBy* options

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -86,7 +86,7 @@ Execute a MATLAB script, function, or statement. Specify the task in your pipeli
 
 Argument                  | Description    
 ------------------------- | --------------- 
-`command`                   | (Required) Script, function, or statement to execute. If the value of `command` is the name of a MATLAB script or function, do not specify the file extension. If you specify more than one MATLAB command, use a comma or semicolon to separate the commands.<br/>**Example:** `'myscript'`<br/>**Example:** `'results = runtests, assertSuccess(results);'` 
+`command`                 | (Required) Script, function, or statement to execute. If the value of `command` is the name of a MATLAB script or function, do not specify the file extension. If you specify more than one MATLAB command, use a comma or semicolon to separate the commands.<br/>**Example:** `'myscript'`<br/>**Example:** `'results = runtests, assertSuccess(results);'` 
 
 MATLAB exits with exit code 0 if the specified script, function, or statement executes successfully without error. Otherwise, MATLAB terminates with a nonzero exit code, which causes the build to fail. You can use the [`assert`](https://www.mathworks.com/help/matlab/ref/assert.html) or [`error`](https://www.mathworks.com/help/matlab/ref/error.html) functions in the command to ensure that builds fail when necessary.
 
@@ -96,10 +96,12 @@ When you use this task, all of the required files must be on the MATLAB search p
 Run all tests in a MATLAB project and generate test artifacts. Specify the task in your pipeline YAML using the `RunMATLABTests` key.
 
 Argument                  | Description    
-------------------------- | --------------- 
-`testResultsJunit`        | (Optional) Path to write test results report in JUnit XML format.<br/>**Example:** `'test-results/results.xml'`
+------------------------- | ---------------
 `codeCoverageCobertura`   | (Optional) Path to write code coverage report in Cobertura XML format.<br/>**Example:** `'code-coverage/coverage.xml'`
-`sourceFolder`      | (Optional) Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list.<br/>**Example:** `'source'`
+`selectByFolder`          | (Optional) Location of the folder used to select test suite elements, relative to the project root folder. To generate a test suite, MATLAB uses only the tests in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list.<br/>**Example:** `'test/unit'`
+`selectByTag`             | (Optional) Test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag.<br/>**Example:** `'Unit'`
+`sourceFolder`            | (Optional) Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list.<br/>**Example:** `'source'`
+`testResultsJunit`        | (Optional) Path to write test results report in JUnit XML format.<br/>**Example:** `'test-results/results.xml'`
 
 MATLAB includes any files in your project that have a **Test** label. If your pipeline does not leverage a MATLAB project or uses a MATLAB release before R2019a, then MATLAB includes all tests in the root of your repository including its subfolders.
 

--- a/overview.md
+++ b/overview.md
@@ -101,7 +101,7 @@ Argument                  | Description
 `selectByFolder`          | (Optional) Location of the folder used to select test suite elements, relative to the project root folder. To generate a test suite, MATLAB uses only the tests in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list.<br/>**Example:** `'test/unit'`
 `selectByTag`             | (Optional) Test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag.<br/>**Example:** `'Unit'`
 `sourceFolder`            | (Optional) Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list.<br/>**Example:** `'source'`
-`testResultsJunit`        | (Optional) Path to write test results report in JUnit XML format.<br/>**Example:** `'test-results/results.xml'`
+`testResultsJUnit`        | (Optional) Path to write test results report in JUnit XML format.<br/>**Example:** `'test-results/results.xml'`
 
 MATLAB includes any files in your project that have a **Test** label. If your pipeline does not leverage a MATLAB project or uses a MATLAB release before R2019a, then MATLAB includes all tests in the root of your repository including its subfolders.
 

--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -8,28 +8,35 @@ import {platform} from "./utils";
 async function run() {
     try {
         taskLib.setResourcePath(path.join( __dirname, "task.json"));
-        const release = taskLib.getInput("release", true);
-        await install(release as string);
+        const release = taskLib.getInput("release");
+        await install(release);
     } catch (err) {
         taskLib.setResult(taskLib.TaskResult.Failed, err.message);
     }
 }
 
-async function install(release: string) {
+async function install(release?: string) {
     const serverType = taskLib.getVariable("System.ServerType");
     if (!serverType || serverType.toLowerCase() !== "hosted") {
         throw new Error(taskLib.loc("InstallNotSupportedOnSelfHosted"));
     }
 
     // install core system dependencies
-    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", release);
+    const depArgs: string[] = [];
+    if (release !== undefined) {
+        depArgs.push(release);
+    }
+    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", depArgs);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
     }
 
     // install ephemeral version of MATLAB
-    exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh",
-        ["--release", release]);
+    const installArgs: string[] = [];
+    if (release !== undefined) {
+        installArgs.push("--release", release);
+    }
+    exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh", installArgs);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
     }

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -17,9 +17,9 @@
             "name": "release",
             "type": "string",
             "label": "Release",
-            "required": true,
+            "required": false,
             "defaultValue": "latest",
-            "helpMarkDown": "MATLAB release to install. You can specify R2020a or a later release. By default, the task installs the latest release of MATLAB."
+            "helpMarkDown": "MATLAB release to install. You can specify R2020a or a later release. If you do not specify `release`, the task installs the latest release of MATLAB."
         }
     ],
     "instanceNameFormat": "Install MATLAB",

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -14,28 +14,12 @@
     },
     "inputs": [
         {
-            "name": "testResultsJUnit",
-            "type": "string",
-            "label": "JUnit-style test results",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Path to write test results report in JUnit XML format."
-        },
-        {
             "name": "codeCoverageCobertura",
             "type": "string",
             "label": "Cobertura code coverage",
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
-        },
-        {
-            "name": "sourceFolder",
-            "type": "string",
-            "label": "Source code folder",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
         },
         {
             "name": "selectByFolder",
@@ -52,6 +36,22 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag."
+        },
+        {
+            "name": "sourceFolder",
+            "type": "string",
+            "label": "Source code folder",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
+        },
+        {
+            "name": "testResultsJUnit",
+            "type": "string",
+            "label": "JUnit-style test results",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Path to write test results report in JUnit XML format."
         }
     ],
     "instanceNameFormat": "Run MATLAB Tests",


### PR DESCRIPTION
- Update doc to include the new `selectByFolder` and `selectByTag` options of the `RunMATLABTests` task
- Change display order of options to be alphabetical
- Fix `release` option on `InstallMATLAB` to be truly optional