### PR TITLE
Added artifact support for model cov & pdf results.

### DIFF
--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -183,7 +183,8 @@ stages:
               grep -v simpleTest test-results/matlab/selectbytag.xml
             displayName: Verify test filtered by tag name
           - bash: |
-              cat << EOF > createModel.m
+              mkdir simtests
+              cat << EOF > simtests/createModel.m
               % Create model
               model = 'new_temp_model';
               new_system(model);
@@ -233,10 +234,11 @@ stages:
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run model creator and test Simulink test generator
             inputs:
-              command: "createModel"
+              command: "cd simtests;createModel"
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
             displayName: Run MATLAB tests and generate Simulink test artifacts
             inputs:
+              selectByFolder: "simtests"
               coberturaModelCoverage: test-results/matlab/modelcoverage.xml
               simulinkTestResults: test-results/matlab/stmResult.mldatx
           - bash: |

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -239,8 +239,8 @@ stages:
             displayName: Run MATLAB tests and generate Simulink test artifacts
             inputs:
               selectByFolder: "simtests"
-              coberturaModelCoverage: test-results/matlab/modelcoverage.xml
-              simulinkTestResults: test-results/matlab/stmResult.mldatx
+              modelCoverageCobertura: test-results/matlab/modelcoverage.xml
+              testResultsSimulinkTest: test-results/matlab/stmResult.mldatx
               testResultsPDF: test-results/matlab/results.pdf
           - bash: |
               set -e

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -245,6 +245,10 @@ stages:
               set -e
               grep -q new_temp_model test-results/matlab/modelcoverage.xml
             displayName: Verify Model coverage was created
+          - bash: |
+              set -e
+              test -f test-results/matlab/stmResult.mldatx
+            displayName: Verify STM report was created
   - stage: publish_prerelease
     displayName: Publish prerelease
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -241,6 +241,7 @@ stages:
               selectByFolder: "simtests"
               coberturaModelCoverage: test-results/matlab/modelcoverage.xml
               simulinkTestResults: test-results/matlab/stmResult.mldatx
+              testResultsPDF: test-results/matlab/results.pdf
           - bash: |
               set -e
               grep -q new_temp_model test-results/matlab/modelcoverage.xml
@@ -249,6 +250,10 @@ stages:
               set -e
               test -f test-results/matlab/stmResult.mldatx
             displayName: Verify STM report was created
+          - bash: |
+              set -e
+              test -f test-results/matlab/results.pdf
+            displayName: Verify PDF report was created
   - stage: publish_prerelease
     displayName: Publish prerelease
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -115,6 +115,8 @@ stages:
         pool:
           name: $(poolName)
           vmImage: $(vmImage)
+        workspace:
+          clean: all
         steps:
           - checkout: none
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -182,7 +182,67 @@ stages:
               grep -v FirstTest test-results/matlab/selectbytag.xml
               grep -v simpleTest test-results/matlab/selectbytag.xml
             displayName: Verify test filtered by tag name
+          - bash: |
+              cat << EOF > createModel.m
+              % Create model
+              model = 'new_temp_model';
+              new_system(model);
+              load_system(model);
 
+              % add blocks
+              add_block('built-in/Inport', [model, '/InputPort'], ...
+                  'Position', [50 50 100 100]);
+              add_block('built-in/Gain', [model, '/Gain'], 'Gain', '1', ...
+                  'Position', [150 50 200 100]);
+              add_block('built-in/Outport', [model, '/OutputPort'], ...
+                  'Position', [250 50 300 100]);
+
+              % add lines
+              add_line(model, 'InputPort/1', 'Gain/1');
+              add_line(model, 'Gain/1', 'OutputPort/1');
+
+              % save system
+              save_system(model);
+              close_system(model);
+
+              % Create Simulink Test File
+              sltest.testmanager.clear;
+              sltest.testmanager.clearResults;
+              tf = sltest.testmanager.TestFile('test.mldatx');
+
+              % Set coverage related options.
+              cs = tf.getCoverageSettings;
+              cs.RecordCoverage = true;
+              cs.MdlRefCoverage = true;
+              cs.MetricSettings = 'd';
+
+              % Set model and collect baseline.
+              ts = tf.getTestSuites;
+              tc = ts.getTestCases;
+              tc.setProperty('model', model);
+              captureBaselineCriteria(tc,'baseline_API.mat',true);
+
+              % Save test file and close.
+              tf.saveToFile;
+              tf.close;
+              sltest.testmanager.close;
+              disp('Created Model and Simulink Test file to simulate the model.');
+              evalin('base', 'clear all');
+              EOF
+            displayName: Create model file and Simulink test.
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
+            displayName: Run model creator and test Simulink test generator
+            inputs:
+              command: "createModel"
+          - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
+            displayName: Run MATLAB tests and generate Simulink test artifacts
+            inputs:
+              coberturaModelCoverage: test-results/matlab/modelcoverage.xml
+              simulinkTestResults: test-results/matlab/stmResult.mldatx
+          - bash: |
+              set -e
+              grep -q new_temp_model test-results/matlab/modelcoverage.xml
+            displayName: Verify Model coverage was created
   - stage: publish_prerelease
     displayName: Publish prerelease
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/tasks/run-matlab-tests/v0/main.ts
+++ b/tasks/run-matlab-tests/v0/main.ts
@@ -35,7 +35,7 @@ async function runTests(options: IRunTestsOptions) {
             `'SelectByFolder','${options.SelectByFolder || ""}',` +
             `'SelectByTag','${options.SelectByTag || ""}',` +
             `'CoberturaModelCoverage','${options.CoberturaModelCoverage || ""}',` +
-            `'SimulinkTestResults','${options.SimulinkTestResults || ""}', ` +
+            `'SimulinkTestResults','${options.SimulinkTestResults || ""}',` +
             `'PDFTestReport','${options.PDFTestReport || ""}');` +
         `disp('Running MATLAB script with contents:');` +
         `disp(testScript.Contents);` +

--- a/tasks/run-matlab-tests/v0/main.ts
+++ b/tasks/run-matlab-tests/v0/main.ts
@@ -13,7 +13,10 @@ async function run() {
             CoberturaCodeCoverage: taskLib.getInput("codeCoverageCobertura"),
             SourceFolder: taskLib.getInput("sourceFolder"),
             SelectByFolder: taskLib.getInput("selectByFolder"),
-            SelectByTag: taskLib.getInput("selectByTag")};
+            SelectByTag: taskLib.getInput("selectByTag"),
+            CoberturaModelCoverage: taskLib.getInput("coberturaModelCoverage"),
+            SimulinkTestResults: taskLib.getInput("simulinkTestResults"),
+            PDFTestReport: taskLib.getInput("testResultsPDF")};
         await runTests(options);
     } catch (err) {
         taskLib.setResult(taskLib.TaskResult.Failed, err.message);
@@ -30,7 +33,10 @@ async function runTests(options: IRunTestsOptions) {
             `'CoberturaCodeCoverage','${options.CoberturaCodeCoverage || ""}',` +
             `'SourceFolder','${options.SourceFolder || ""}',` +
             `'SelectByFolder','${options.SelectByFolder || ""}',` +
-            `'SelectByTag','${options.SelectByTag || ""}');` +
+            `'SelectByTag','${options.SelectByTag || ""}',` +
+            `'CoberturaModelCoverage','${options.CoberturaModelCoverage || ""}',` +
+            `'SimulinkTestResults','${options.SimulinkTestResults || ""}', ` +
+            `'PDFTestReport','${options.PDFTestReport || ""}');` +
         `disp('Running MATLAB script with contents:');` +
         `disp(testScript.Contents);` +
         `fprintf('__________\\n\\n');` +
@@ -47,6 +53,9 @@ interface IRunTestsOptions {
     SourceFolder?: string;
     SelectByFolder?: string;
     SelectByTag?: string;
+    CoberturaModelCoverage?: string;
+    SimulinkTestResults?: string;
+    PDFTestReport?: string;
 }
 
 run();

--- a/tasks/run-matlab-tests/v0/main.ts
+++ b/tasks/run-matlab-tests/v0/main.ts
@@ -14,8 +14,8 @@ async function run() {
             SourceFolder: taskLib.getInput("sourceFolder"),
             SelectByFolder: taskLib.getInput("selectByFolder"),
             SelectByTag: taskLib.getInput("selectByTag"),
-            CoberturaModelCoverage: taskLib.getInput("coberturaModelCoverage"),
-            SimulinkTestResults: taskLib.getInput("simulinkTestResults"),
+            CoberturaModelCoverage: taskLib.getInput("modelCoverageCobertura"),
+            SimulinkTestResults: taskLib.getInput("testResultsSimulinkTest"),
             PDFTestReport: taskLib.getInput("testResultsPDF")};
         await runTests(options);
     } catch (err) {

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -33,7 +33,7 @@
             "label": "Cobertura code coverage",
             "defaultValue": "",
             "required": false,
-            "groupName": "coverageArtifacts"
+            "groupName": "coverageArtifacts",
             "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
         },
         {

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -41,6 +41,7 @@
             "type": "string",
             "label": "Cobertura model coverage",
             "defaultValue": "",
+            "groupName": "coverageArtifacts",
             "required": false,
             "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
         },
@@ -49,6 +50,7 @@
             "type": "string",
             "label": "Simulink test results",
             "defaultValue": "",
+            "groupName": "testArtifact",
             "required": false,
             "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format."
         },
@@ -57,22 +59,25 @@
             "type": "string",
             "label": "Test results in PDF format",
             "defaultValue": "",
+            "groupName": "testArtifact",
             "required": false,
             "helpMarkDown": "Path to write test results in PDF format."
         },
         {
             "name": "selectByFolder",
             "type": "string",
-            "label": "Select by folder",
+            "label": "By folder name",
             "defaultValue": "",
+            "groupName": "filterTests",
             "required": false,
             "helpMarkDown": "Location of the folder used to select test suite elements, relative to the project root folder. To generate a test suite, MATLAB uses only the tests in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
         },
         {
             "name": "selectByTag",
             "type": "string",
-            "label": "Select by tag",
+            "label": "By tag",
             "defaultValue": "",
+            "groupName": "filterTests",
             "required": false,
             "helpMarkDown": "Test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag."
         },
@@ -89,6 +94,7 @@
             "type": "string",
             "label": "JUnit-style test results",
             "defaultValue": "",
+            "groupName": "testArtifact",
             "required": false,
             "helpMarkDown": "Path to write test results report in JUnit XML format."
         }

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -14,15 +14,15 @@
     },
     "groups": [
         {
-            "name": "testArtifact"
+            "name": "testArtifact",
             "displayName": "Generate Test Artifacts"
         },
         {
-            "name": "coverageArtifacts"
+            "name": "coverageArtifacts",
             "displayName": "Generate Coverage Artifacts"
         },
         {
-          "name": "filterTests"
+          "name": "filterTests",
           "displayName": "Filter Tests"
         }
     ],

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -12,51 +12,6 @@
         "Minor": 1,
         "Patch": 0
     },
-    "groups":{
-      "label": "Test Artifcats"
-      "inputs": [
-          {
-              "name": "codeCoverageCobertura",
-              "type": "string",
-              "label": "Cobertura code coverage",
-              "defaultValue": "",
-              "required": false,
-              "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
-          },
-          {
-              "name": "modelCoverageCobertura",
-              "type": "string",
-              "label": "Cobertura model coverage",
-              "defaultValue": "",
-              "required": false,
-              "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
-          },
-          {
-              "name": "testResultsSimulinkTest",
-              "type": "string",
-              "label": "Simulink test results",
-              "defaultValue": "",
-              "required": false,
-              "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format."
-          },
-          {
-              "name": "testResultsPDF",
-              "type": "string",
-              "label": "Test results in PDF format",
-              "defaultValue": "",
-              "required": false,
-              "helpMarkDown": "Path to write test results in PDF format."
-          },
-          {
-              "name": "testResultsJUnit",
-              "type": "string",
-              "label": "JUnit-style test results",
-              "defaultValue": "",
-              "required": false,
-              "helpMarkDown": "Path to write test results report in JUnit XML format."
-          }
-      ],
-    },
     "inputs": [
         {
             "name": "codeCoverageCobertura",

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -22,6 +22,30 @@
             "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
         },
         {
+            "name": "coberturaModelCoverage",
+            "type": "string",
+            "label": "Cobertura model coverage",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
+        },
+        {
+            "name": "simulinkTestResults",
+            "type": "string",
+            "label": "Simulink test results",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Path to write Simulink test results in mldatx format."
+        },
+        {
+            "name": "testResultsPDF",
+            "type": "string",
+            "label": "Test results in PDF format",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Path to write test results in PDF format."
+        },
+        {
             "name": "selectByFolder",
             "type": "string",
             "label": "Select by folder",

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -14,7 +14,7 @@
     },
     "groups": [
         {
-            "name": "testArtifact",
+            "name": "testArtifacts",
             "displayName": "Generate Test Artifacts"
         },
         {
@@ -43,34 +43,34 @@
             "defaultValue": "",
             "groupName": "coverageArtifacts",
             "required": false,
-            "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
+            "helpMarkDown": "Path to write model coverage report in Cobertura XML format (requires Simulink Coverage™ license and is supported in MATLAB R2018b or later)."
         },
         {
             "name": "testResultsSimulinkTest",
             "type": "string",
             "label": "Simulink test results",
             "defaultValue": "",
-            "groupName": "testArtifact",
+            "groupName": "testArtifacts",
             "required": false,
-            "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format."
+            "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format (requires Simulink Test license and is supported in MATLAB R2019a or later)."
         },
         {
             "name": "testResultsPDF",
             "type": "string",
-            "label": "Test results in PDF format",
+            "label": "PDF test report ",
             "defaultValue": "",
-            "groupName": "testArtifact",
+            "groupName": "testArtifacts",
             "required": false,
-            "helpMarkDown": "Path to write test results in PDF format."
+            "helpMarkDown": "Path to write test results report in PDF format (currently not supported on macOS platforms)."
         },
         {
             "name": "selectByFolder",
             "type": "string",
-            "label": "By folder name",
+            "label": "By folder",
             "defaultValue": "",
             "groupName": "filterTests",
             "required": false,
-            "helpMarkDown": "Location of the folder used to select test suite elements, relative to the project root folder. To generate a test suite, MATLAB uses only the tests in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
+            "helpMarkDown": "Locations of the folders used to select test suite elements, relative to the project root folder. To create a test suite, the task uses only the tests in the specified folders and their subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
         },
         {
             "name": "selectByTag",
@@ -79,12 +79,12 @@
             "defaultValue": "",
             "groupName": "filterTests",
             "required": false,
-            "helpMarkDown": "Test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag."
+            "helpMarkDown": "Test tag used to select test suite elements. To create a test suite, the task uses only the test elements with the specified tag."
         },
         {
             "name": "sourceFolder",
             "type": "string",
-            "label": "Source code folder",
+            "label": "Source folder",
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Location of the folder containing source code, relative to the project root folder. The specified folder and its subfolders are added to the top of the MATLAB search path. To generate a code coverage report, MATLAB uses only the source code in the specified folder and its subfolders. You can specify multiple folders using a colon-separated or a semicolon-separated list."
@@ -94,7 +94,7 @@
             "type": "string",
             "label": "JUnit-style test results",
             "defaultValue": "",
-            "groupName": "testArtifact",
+            "groupName": "testArtifacts",
             "required": false,
             "helpMarkDown": "Path to write test results report in JUnit XML format."
         }

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -12,6 +12,51 @@
         "Minor": 1,
         "Patch": 0
     },
+    "groups":{
+      "label": "Test Artifcats"
+      "inputs": [
+          {
+              "name": "codeCoverageCobertura",
+              "type": "string",
+              "label": "Cobertura code coverage",
+              "defaultValue": "",
+              "required": false,
+              "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
+          },
+          {
+              "name": "modelCoverageCobertura",
+              "type": "string",
+              "label": "Cobertura model coverage",
+              "defaultValue": "",
+              "required": false,
+              "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
+          },
+          {
+              "name": "testResultsSimulinkTest",
+              "type": "string",
+              "label": "Simulink test results",
+              "defaultValue": "",
+              "required": false,
+              "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format."
+          },
+          {
+              "name": "testResultsPDF",
+              "type": "string",
+              "label": "Test results in PDF format",
+              "defaultValue": "",
+              "required": false,
+              "helpMarkDown": "Path to write test results in PDF format."
+          },
+          {
+              "name": "testResultsJUnit",
+              "type": "string",
+              "label": "JUnit-style test results",
+              "defaultValue": "",
+              "required": false,
+              "helpMarkDown": "Path to write test results report in JUnit XML format."
+          }
+      ],
+    },
     "inputs": [
         {
             "name": "codeCoverageCobertura",

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -35,7 +35,7 @@
             "label": "Simulink test results",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Path to write Simulink test results in mldatx format."
+            "helpMarkDown": "Path to export Simulink Test Manager results in MLDATX format."
         },
         {
             "name": "testResultsPDF",

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -12,6 +12,20 @@
         "Minor": 1,
         "Patch": 0
     },
+    "groups": [
+        {
+            "name": "testArtifact"
+            "displayName": "Generate Test Artifacts"
+        },
+        {
+            "name": "coverageArtifacts"
+            "displayName": "Generate Coverage Artifacts"
+        },
+        {
+          "name": "filterTests"
+          "displayName": "Filter Tests"
+        }
+    ],
     "inputs": [
         {
             "name": "codeCoverageCobertura",
@@ -19,6 +33,7 @@
             "label": "Cobertura code coverage",
             "defaultValue": "",
             "required": false,
+            "groupName": "coverageArtifacts"
             "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
         },
         {

--- a/tasks/run-matlab-tests/v0/task.json
+++ b/tasks/run-matlab-tests/v0/task.json
@@ -22,7 +22,7 @@
             "helpMarkDown": "Path to write code coverage report in Cobertura XML format."
         },
         {
-            "name": "coberturaModelCoverage",
+            "name": "modelCoverageCobertura",
             "type": "string",
             "label": "Cobertura model coverage",
             "defaultValue": "",
@@ -30,7 +30,7 @@
             "helpMarkDown": "Path to write model coverage report in Cobertura XML format."
         },
         {
-            "name": "simulinkTestResults",
+            "name": "testResultsSimulinkTest",
             "type": "string",
             "label": "Simulink test results",
             "defaultValue": "",

--- a/tasks/run-matlab-tests/v0/test/common.ts
+++ b/tasks/run-matlab-tests/v0/test/common.ts
@@ -10,6 +10,9 @@ export function runCmdArg(
                     source: string,
                     selectByFolder: string,
                     selectByTag: string,
+                    coberturaModelCoverage: string,
+                    simulinkTestResults: string,
+                    testResultsPDF: string,
                 ) {
     return "addpath('" + path.join(path.dirname(__dirname), "scriptgen") + "');" +
         "testScript = genscript('Test'," +
@@ -17,7 +20,10 @@ export function runCmdArg(
             "'CoberturaCodeCoverage','" + cobertura + "'," +
             "'SourceFolder','" + source + "'," +
             "'SelectByFolder','" + selectByFolder + "'," +
-            "'SelectByTag','" + selectByTag + "');" +
+            "'SelectByTag','" + selectByTag + "'," +
+            "'CoberturaModelCoverage','" + coberturaModelCoverage + "'," +
+            "'SimulinkTestResults','" + simulinkTestResults + "'," +
+            "'PDFTestReport','" + testResultsPDF + "');" +
         `disp('Running MATLAB script with contents:');` +
         `disp(testScript.Contents);` +
         `fprintf('__________\\n\\n');` +

--- a/tasks/run-matlab-tests/v0/test/common.ts
+++ b/tasks/run-matlab-tests/v0/test/common.ts
@@ -10,8 +10,8 @@ export function runCmdArg(
                     source: string,
                     selectByFolder: string,
                     selectByTag: string,
-                    coberturaModelCoverage: string,
-                    simulinkTestResults: string,
+                    modelCoverageCobertura: string,
+                    testResultsSimulinkTest: string,
                     testResultsPDF: string,
                 ) {
     return "addpath('" + path.join(path.dirname(__dirname), "scriptgen") + "');" +
@@ -21,8 +21,8 @@ export function runCmdArg(
             "'SourceFolder','" + source + "'," +
             "'SelectByFolder','" + selectByFolder + "'," +
             "'SelectByTag','" + selectByTag + "'," +
-            "'CoberturaModelCoverage','" + coberturaModelCoverage + "'," +
-            "'SimulinkTestResults','" + simulinkTestResults + "'," +
+            "'CoberturaModelCoverage','" + modelCoverageCobertura + "'," +
+            "'SimulinkTestResults','" + testResultsSimulinkTest + "'," +
             "'PDFTestReport','" + testResultsPDF + "');" +
         `disp('Running MATLAB script with contents:');` +
         `disp(testScript.Contents);` +

--- a/tasks/run-matlab-tests/v0/test/failRunTests.ts
+++ b/tasks/run-matlab-tests/v0/test/failRunTests.ts
@@ -17,7 +17,7 @@ const a: ma.TaskLibAnswers = {
         [runCmdPath]: true,
     },
     exec: {
-        [runCmdPath + ".sh " + runCmdArg("", "", "", "", "","","","")]: {
+        [runCmdPath + ".sh " + runCmdArg("", "", "", "", "", "", "", "")]: {
             code: 1,
             stdout: "tests failed",
         },

--- a/tasks/run-matlab-tests/v0/test/failRunTests.ts
+++ b/tasks/run-matlab-tests/v0/test/failRunTests.ts
@@ -17,7 +17,7 @@ const a: ma.TaskLibAnswers = {
         [runCmdPath]: true,
     },
     exec: {
-        [runCmdPath + ".sh " + runCmdArg("", "", "", "", "")]: {
+        [runCmdPath + ".sh " + runCmdArg("", "", "", "", "","","","")]: {
             code: 1,
             stdout: "tests failed",
         },

--- a/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
@@ -13,10 +13,9 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
-tr.setInput("coberturaModelCoverage","modelcoverage.xml");
-tr.setInput("simulinkTestResults","stmresults.mldatx");
-tr.setInput("testResultsPDF","results.pdf");
-
+tr.setInput("coberturaModelCoverage", "modelcoverage.xml");
+tr.setInput("simulinkTestResults", "stmresults.mldatx");
+tr.setInput("testResultsPDF", "results.pdf");
 
 tr.registerMock("./utils", {
     platform: () => "linux",
@@ -27,7 +26,7 @@ const a: ma.TaskLibAnswers = {
         [runCmdPath]: true,
     },
     exec: {
-        [runCmdPath + ".sh " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED","modelcoverage.xml", "stmresults.mldatx", "results.pdf")]: {
+        [runCmdPath + ".sh " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED", "modelcoverage.xml", "stmresults.mldatx", "results.pdf")]: {
             code: 0,
             stdout: "ran tests",
         },

--- a/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
@@ -13,8 +13,8 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
-tr.setInput("coberturaModelCoverage", "modelcoverage.xml");
-tr.setInput("simulinkTestResults", "stmresults.mldatx");
+tr.setInput("modelCoverageCobertura", "modelcoverage.xml");
+tr.setInput("testResultsSimulinkTest", "stmresults.mldatx");
 tr.setInput("testResultsPDF", "results.pdf");
 
 tr.registerMock("./utils", {

--- a/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsLinux.ts
@@ -13,6 +13,10 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
+tr.setInput("coberturaModelCoverage","modelcoverage.xml");
+tr.setInput("simulinkTestResults","stmresults.mldatx");
+tr.setInput("testResultsPDF","results.pdf");
+
 
 tr.registerMock("./utils", {
     platform: () => "linux",
@@ -23,7 +27,7 @@ const a: ma.TaskLibAnswers = {
         [runCmdPath]: true,
     },
     exec: {
-        [runCmdPath + ".sh " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED")]: {
+        [runCmdPath + ".sh " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED","modelcoverage.xml", "stmresults.mldatx", "results.pdf")]: {
             code: 0,
             stdout: "ran tests",
         },

--- a/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
@@ -13,6 +13,9 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
+tr.setInput("coberturaModelCoverage","modelcoverage.xml");
+tr.setInput("simulinkTestResults","stmresults.mldatx");
+tr.setInput("testResultsPDF","results.pdf");
 
 tr.registerMock("./utils", {
     platform: () => "win32",
@@ -23,7 +26,7 @@ const a: ma.TaskLibAnswers = {
         [runCmdPath]: true,
     },
     exec: {
-        [runCmdPath + ".bat " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED")]: {
+        [runCmdPath + ".bat " + runCmdArg("results.xml", "coverage.xml", "source", "tests/filteredTest", "FILTERED", "modelcoverage.xml", "stmresults.mldatx", "results.pdf")]: {
             code: 0,
             stdout: "ran tests",
         },

--- a/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
@@ -13,8 +13,8 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
-tr.setInput("coberturaModelCoverage", "modelcoverage.xml");
-tr.setInput("simulinkTestResults", "stmresults.mldatx");
+tr.setInput("modelCoverageCobertura", "modelcoverage.xml");
+tr.setInput("testResultsSimulinkTest", "stmresults.mldatx");
 tr.setInput("testResultsPDF", "results.pdf");
 
 tr.registerMock("./utils", {

--- a/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
+++ b/tasks/run-matlab-tests/v0/test/runTestsWindows.ts
@@ -13,9 +13,9 @@ tr.setInput("codeCoverageCobertura", "coverage.xml");
 tr.setInput("sourceFolder", "source");
 tr.setInput("selectByFolder", "tests/filteredTest");
 tr.setInput("selectByTag", "FILTERED");
-tr.setInput("coberturaModelCoverage","modelcoverage.xml");
-tr.setInput("simulinkTestResults","stmresults.mldatx");
-tr.setInput("testResultsPDF","results.pdf");
+tr.setInput("coberturaModelCoverage", "modelcoverage.xml");
+tr.setInput("simulinkTestResults", "stmresults.mldatx");
+tr.setInput("testResultsPDF", "results.pdf");
 
 tr.registerMock("./utils", {
     platform: () => "win32",


### PR DESCRIPTION
* Added support for STM result 
* Added support for model coverage 
* Added support for PDF report 
eg:
`
 
        displayName: Run MATLAB tests and generate Simulink test artifacts
            inputs:
              selectByFolder: "simtests"
              coberturaModelCoverage: test-results/matlab/modelcoverage.xml
              simulinkTestResults: test-results/matlab/stmResult.mldatx
              testResultsPDF: test-results/matlab/results.pdf`

Note: Integ test on self-hosted windows azure instance fails as Simulink is not installed on those windows systems. 