### PR TITLE
Add limited, undocumented, Windows and macOS support

### DIFF
--- a/build-test-publish.pipeline.yml
+++ b/build-test-publish.pipeline.yml
@@ -9,7 +9,7 @@ variables:
   vsixFile: '$(vsixFolder)/matlab-$(Build.BuildNumber).vsix'
 
 pool:
-  vmImage: ubuntu-16.04
+  vmImage: ubuntu-latest
 
 steps:
   - task: NodeTool@0

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -255,10 +255,12 @@ stages:
               evalin('base', 'clear all');
               EOF
             displayName: Create model file and Simulink test.
+            condition: eq(variables['Agent.OS'], 'Linux')
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABCommand.RunMATLABCommand@0
             displayName: Run model creator and test Simulink test generator
             inputs:
               command: "cd simtests;createModel"
+            condition: eq(variables['Agent.OS'], 'Linux')
           - task: MathWorks.matlab-azure-devops-extension-dev.RunMATLABTests.RunMATLABTests@0
             displayName: Run MATLAB tests and generate Simulink test artifacts
             inputs:
@@ -266,18 +268,22 @@ stages:
               modelCoverageCobertura: test-results/matlab/modelcoverage.xml
               testResultsSimulinkTest: test-results/matlab/stmResult.mldatx
               testResultsPDF: test-results/matlab/results.pdf
+            condition: eq(variables['Agent.OS'], 'Linux')
           - bash: |
               set -e
               grep -q new_temp_model test-results/matlab/modelcoverage.xml
             displayName: Verify Model coverage was created
+            condition: eq(variables['Agent.OS'], 'Linux')
           - bash: |
               set -e
               test -f test-results/matlab/stmResult.mldatx
             displayName: Verify STM report was created
+            condition: eq(variables['Agent.OS'], 'Linux')
           - bash: |
               set -e
               test -f test-results/matlab/results.pdf
             displayName: Verify PDF report was created
+            condition: eq(variables['Agent.OS'], 'Linux')
   - stage: publish_prerelease
     displayName: Publish prerelease
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -56,10 +56,10 @@ stages:
           - task: MathWorks.matlab-azure-devops-extension-dev.InstallMATLAB.InstallMATLAB@0
             displayName: Install MATLAB
             inputs:
-              release: R2020a
+              release: R2021a
           - bash: |
               set -e
-              matlab -batch "assert(strcmp(version('-release'),'2020a'))"
+              matlab -batch "assert(strcmp(version('-release'),'2021a'))"
             displayName: Check matlab release
 
       - job: test_run_command

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -33,7 +33,11 @@ stages:
           - bash: |
               set -e
               matlab -batch version
-              mex -h
+              if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
+                mex.bat -h
+              else
+                mex -h
+              fi
             displayName: Check matlab and mex
 
       - job: test_install_release

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -33,6 +33,7 @@ stages:
           - bash: |
               set -e
               matlab -batch version
+              os=$(uname)
               if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
                 mex.bat -h
               else

--- a/integ-test-promote.pipeline.yml
+++ b/integ-test-promote.pipeline.yml
@@ -16,7 +16,13 @@ stages:
           matrix:
             microsoft_hosted_linux:
               poolName: Azure Pipelines
-              vmImage: ubuntu-16.04
+              vmImage: ubuntu-latest
+            microsoft_hosted_macos:
+              poolName: Azure Pipelines
+              vmImage: macOS-latest
+            microsoft_hosted_windows:
+              poolName: Azure Pipelines
+              vmImage: windows-latest
         pool:
           name: $(poolName)
           vmImage: $(vmImage)
@@ -35,7 +41,13 @@ stages:
           matrix:
             microsoft_hosted_linux:
               poolName: Azure Pipelines
-              vmImage: ubuntu-16.04
+              vmImage: ubuntu-latest
+            microsoft_hosted_macos:
+              poolName: Azure Pipelines
+              vmImage: macOS-latest
+            microsoft_hosted_windows:
+              poolName: Azure Pipelines
+              vmImage: windows-latest
         pool:
           name: $(poolName)
           vmImage: $(vmImage)
@@ -55,7 +67,13 @@ stages:
           matrix:
             microsoft_hosted_linux:
               poolName: Azure Pipelines
-              vmImage: ubuntu-16.04
+              vmImage: ubuntu-latest
+            microsoft_hosted_macos:
+              poolName: Azure Pipelines
+              vmImage: macOS-latest
+            microsoft_hosted_windows:
+              poolName: Azure Pipelines
+              vmImage: windows-latest
             self_hosted_windows:
               poolName: vmssagentpool
               vmImage: # blank for self-hosted
@@ -108,7 +126,7 @@ stages:
           matrix:
             microsoft_hosted_linux:
               poolName: Azure Pipelines
-              vmImage: ubuntu-16.04
+              vmImage: ubuntu-latest
             self_hosted_windows:
               poolName: vmssagentpool
               vmImage: # blank for self-hosted
@@ -260,7 +278,7 @@ stages:
     displayName: Publish prerelease
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
     jobs:
       - deployment: publish_prerelease
         environment: prerelease
@@ -300,7 +318,7 @@ stages:
     displayName: Publish release
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
     jobs:
       - deployment: publish_release
         environment: release

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "mocha": "^8.3.2",
                 "shelljs": "^0.8.4",
                 "sync-request": "^6.1.0",
-                "tfx-cli": "^0.9.2",
+                "tfx-cli": "^0.10.0",
                 "tslint": "^5.20.1",
                 "typescript": "^4.2.4"
             }
@@ -368,27 +368,14 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/azure-devops-node-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.1.1.tgz",
-            "integrity": "sha512-TIb69NbHOJ/OTvfI1iazMzw/wG9A+ORCYibZCf5wDQFUyYzjCNVUA9QskAW1BGOulwyulGpqWXClCo4KoBaP0Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
             "dev": true,
             "dependencies": {
-                "tunnel": "0.0.4",
-                "typed-rest-client": "1.2.0",
-                "underscore": "1.8.3"
+                "tunnel": "0.0.6",
+                "typed-rest-client": "^1.8.4"
             }
         },
         "node_modules/balanced-match": {
@@ -793,13 +780,6 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "node_modules/core-js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-            "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-            "dev": true
-        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -942,38 +922,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/deep-equal": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-            "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "es-get-iterator": "^1.1.1",
-                "get-intrinsic": "^1.0.1",
-                "is-arguments": "^1.0.4",
-                "is-date-object": "^1.0.2",
-                "is-regex": "^1.1.1",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.4",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "regexp.prototype.flags": "^1.3.0",
-                "side-channel": "^1.0.3",
-                "which-boxed-primitive": "^1.0.1",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/deep-equal/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true
-        },
         "node_modules/define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1060,31 +1008,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-            "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.0",
-                "has-symbols": "^1.0.1",
-                "is-arguments": "^1.1.0",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.5",
-                "isarray": "^2.0.5"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-get-iterator/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true
-        },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -1101,12 +1024,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/es6-promise": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-            "dev": true
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -1214,12 +1131,6 @@
             "dependencies": {
                 "is-callable": "^1.1.3"
             }
-        },
-        "node_modules/foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
         },
         "node_modules/form-data": {
             "version": "2.5.1",
@@ -1518,15 +1429,6 @@
             "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
             "dev": true
         },
-        "node_modules/i": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4"
-            }
-        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1602,22 +1504,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -1735,15 +1621,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-negative-zero": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -1805,15 +1682,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1849,43 +1717,6 @@
             "engines": {
                 "node": ">= 0.4"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
-            "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-            "dev": true,
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "es-abstract": "^1.18.5",
-                "foreach": "^2.0.5",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakmap": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-            "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-            "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1954,43 +1785,16 @@
             "dev": true
         },
         "node_modules/jszip": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+            "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
             "dev": true,
             "dependencies": {
-                "core-js": "~2.3.0",
-                "es6-promise": "~3.0.2",
-                "lie": "~3.1.0",
+                "lie": "~3.3.0",
                 "pako": "~1.0.2",
-                "readable-stream": "~2.0.6"
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
             }
-        },
-        "node_modules/jszip/node_modules/process-nextick-args": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-            "dev": true
-        },
-        "node_modules/jszip/node_modules/readable-stream": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-            "dev": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/jszip/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-            "dev": true
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -2014,9 +1818,9 @@
             }
         },
         "node_modules/lie": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "dependencies": {
                 "immediate": "~3.0.5"
@@ -2260,15 +2064,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/ncp": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-            "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-            "dev": true,
-            "bin": {
-                "ncp": "bin/ncp"
-            }
-        },
         "node_modules/normalize-package-data": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -2310,22 +2105,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
             "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -2524,15 +2303,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pkginfo": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2549,20 +2319,26 @@
             }
         },
         "node_modules/prompt": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-            "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.2.0.tgz",
+            "integrity": "sha512-iGerYRpRUg5ZyC+FJ/25G5PUKuWAGRjW1uOlhX7Pi3O5YygdK6R+KEaBjRbHSkU5vfS5PZCltSPZdDtUYwRCZA==",
             "dev": true,
             "dependencies": {
-                "pkginfo": "0.x.x",
+                "async": "~0.9.0",
+                "colors": "^1.1.2",
                 "read": "1.0.x",
                 "revalidator": "0.1.x",
-                "utile": "0.2.x",
-                "winston": "0.8.x"
+                "winston": "2.x"
             },
             "engines": {
                 "node": ">= 0.6.6"
             }
+        },
+        "node_modules/prompt/node_modules/async": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+            "dev": true
         },
         "node_modules/pseudomap": {
             "version": "1.0.2",
@@ -2714,22 +2490,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -2765,18 +2525,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
             }
         },
         "node_modules/safe-buffer": {
@@ -2845,6 +2593,15 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/shebang-command": {
@@ -3111,27 +2868,27 @@
             }
         },
         "node_modules/tfx-cli": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.2.tgz",
-            "integrity": "sha512-//TwhDpxuog4RwbQ31fQDmzLEBIBXsBhoV+tSVHtkqlTOOTMn52eNOVkTDcsH35fttQstrNEvOFM6pCCo2jx3w==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.10.0.tgz",
+            "integrity": "sha512-8Uwtw+VMoFjEKkq2e71afvATdNPanLeYwzozibdfVKbAH93PR4hA8L7B1GAd2HCk4k0Jr1SUE9NclxQ38oN1aQ==",
             "dev": true,
             "dependencies": {
                 "app-root-path": "1.0.0",
                 "archiver": "2.0.3",
                 "async": "^1.4.0",
-                "azure-devops-node-api": "^8.1.1",
+                "azure-devops-node-api": "^10.2.2",
                 "clipboardy": "~1.2.3",
                 "colors": "~1.3.0",
                 "glob": "7.1.2",
                 "jju": "^1.4.0",
                 "json-in-place": "^1.0.1",
-                "jszip": "~3.1.5",
-                "lodash": "~4.17.11",
-                "minimist": "^1.1.2",
+                "jszip": "^3.7.1",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.5",
                 "mkdirp": "^0.5.1",
                 "onecolor": "^2.5.0",
                 "os-homedir": "^1.0.1",
-                "prompt": "^0.2.14",
+                "prompt": "^1.2.0",
                 "read": "^1.0.6",
                 "shelljs": "^0.5.1",
                 "tmp": "0.0.26",
@@ -3440,9 +3197,9 @@
             }
         },
         "node_modules/tunnel": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3461,13 +3218,14 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+            "version": "1.8.6",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
+            "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
             "dev": true,
             "dependencies": {
-                "tunnel": "0.0.4",
-                "underscore": "1.8.3"
+                "qs": "^6.9.1",
+                "tunnel": "0.0.6",
+                "underscore": "^1.12.1"
             }
         },
         "node_modules/typedarray": {
@@ -3505,9 +3263,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
             "dev": true
         },
         "node_modules/util-deprecate": {
@@ -3531,29 +3289,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/utile": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-            "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
-            "dev": true,
-            "dependencies": {
-                "async": "~0.2.9",
-                "deep-equal": "*",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "0.4.x",
-                "rimraf": "2.x.x"
-            },
-            "engines": {
-                "node": ">= 0.6.4"
-            }
-        },
-        "node_modules/utile/node_modules/async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-            "dev": true
         },
         "node_modules/uuid": {
             "version": "3.4.0",
@@ -3624,41 +3359,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/which-collection": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-            "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-            "dev": true,
-            "dependencies": {
-                "is-map": "^2.0.1",
-                "is-set": "^2.0.1",
-                "is-weakmap": "^2.0.1",
-                "is-weakset": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
-            "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-            "dev": true,
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "es-abstract": "^1.18.5",
-                "foreach": "^2.0.5",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/wide-align": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -3675,45 +3375,35 @@
             "dev": true
         },
         "node_modules/winston": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-            "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+            "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
             "dev": true,
             "dependencies": {
-                "async": "0.2.x",
-                "colors": "0.6.x",
+                "async": "~1.0.0",
+                "colors": "1.0.x",
                 "cycle": "1.0.x",
                 "eyes": "0.1.x",
                 "isstream": "0.1.x",
-                "pkginfo": "0.3.x",
                 "stack-trace": "0.0.x"
             },
             "engines": {
-                "node": ">= 0.6.0"
+                "node": ">= 0.10.0"
             }
         },
         "node_modules/winston/node_modules/async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+            "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
             "dev": true
         },
         "node_modules/winston/node_modules/colors": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-            "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
             "dev": true,
             "engines": {
                 "node": ">=0.1.90"
-            }
-        },
-        "node_modules/winston/node_modules/pkginfo": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-            "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4.0"
             }
         },
         "node_modules/workerpool": {
@@ -4261,21 +3951,14 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
-        "available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "dev": true
-        },
         "azure-devops-node-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.1.1.tgz",
-            "integrity": "sha512-TIb69NbHOJ/OTvfI1iazMzw/wG9A+ORCYibZCf5wDQFUyYzjCNVUA9QskAW1BGOulwyulGpqWXClCo4KoBaP0Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
             "dev": true,
             "requires": {
-                "tunnel": "0.0.4",
-                "typed-rest-client": "1.2.0",
-                "underscore": "1.8.3"
+                "tunnel": "0.0.6",
+                "typed-rest-client": "^1.8.4"
             }
         },
         "balanced-match": {
@@ -4584,12 +4267,6 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "core-js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4700,37 +4377,6 @@
                 }
             }
         },
-        "deep-equal": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-            "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.0",
-                "es-get-iterator": "^1.1.1",
-                "get-intrinsic": "^1.0.1",
-                "is-arguments": "^1.0.4",
-                "is-date-object": "^1.0.2",
-                "is-regex": "^1.1.1",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.4",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "regexp.prototype.flags": "^1.3.0",
-                "side-channel": "^1.0.3",
-                "which-boxed-primitive": "^1.0.1",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.2"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-                    "dev": true
-                }
-            }
-        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -4802,30 +4448,6 @@
                 "unbox-primitive": "^1.0.1"
             }
         },
-        "es-get-iterator": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-            "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.0",
-                "has-symbols": "^1.0.1",
-                "is-arguments": "^1.1.0",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.5",
-                "isarray": "^2.0.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-                    "dev": true
-                }
-            }
-        },
         "es-to-primitive": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -4836,12 +4458,6 @@
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
-        },
-        "es6-promise": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-            "dev": true
         },
         "escalade": {
             "version": "3.1.1",
@@ -4915,12 +4531,6 @@
             "requires": {
                 "is-callable": "^1.1.3"
             }
-        },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
         },
         "form-data": {
             "version": "2.5.1",
@@ -5141,12 +4751,6 @@
                 }
             }
         },
-        "i": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
-            "dev": true
-        },
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5197,16 +4801,6 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
-        },
-        "is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            }
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -5287,12 +4881,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "dev": true
-        },
         "is-negative-zero": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -5330,12 +4918,6 @@
                 "has-tostringtag": "^1.0.0"
             }
         },
-        "is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "dev": true
-        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -5359,31 +4941,6 @@
             "requires": {
                 "has-symbols": "^1.0.2"
             }
-        },
-        "is-typed-array": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
-            "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-            "dev": true,
-            "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "es-abstract": "^1.18.5",
-                "foreach": "^2.0.5",
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-weakmap": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-            "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-            "dev": true
-        },
-        "is-weakset": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-            "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
-            "dev": true
         },
         "isarray": {
             "version": "1.0.0",
@@ -5446,44 +5003,15 @@
             "dev": true
         },
         "jszip": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+            "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
             "dev": true,
             "requires": {
-                "core-js": "~2.3.0",
-                "es6-promise": "~3.0.2",
-                "lie": "~3.1.0",
+                "lie": "~3.3.0",
                 "pako": "~1.0.2",
-                "readable-stream": "~2.0.6"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
             }
         },
         "kind-of": {
@@ -5502,9 +5030,9 @@
             }
         },
         "lie": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "requires": {
                 "immediate": "~3.0.5"
@@ -5691,12 +5219,6 @@
             "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
             "dev": true
         },
-        "ncp": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-            "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-            "dev": true
-        },
         "normalize-package-data": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -5729,16 +5251,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
             "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "dev": true
-        },
-        "object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            }
         },
         "object-keys": {
             "version": "1.1.1",
@@ -5874,12 +5386,6 @@
             "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
             "dev": true
         },
-        "pkginfo": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-            "dev": true
-        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5896,16 +5402,24 @@
             }
         },
         "prompt": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-            "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.2.0.tgz",
+            "integrity": "sha512-iGerYRpRUg5ZyC+FJ/25G5PUKuWAGRjW1uOlhX7Pi3O5YygdK6R+KEaBjRbHSkU5vfS5PZCltSPZdDtUYwRCZA==",
             "dev": true,
             "requires": {
-                "pkginfo": "0.x.x",
+                "async": "~0.9.0",
+                "colors": "^1.1.2",
                 "read": "1.0.x",
                 "revalidator": "0.1.x",
-                "utile": "0.2.x",
-                "winston": "0.8.x"
+                "winston": "2.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                }
             }
         },
         "pseudomap": {
@@ -6021,16 +5535,6 @@
                 "strip-indent": "^4.0.0"
             }
         },
-        "regexp.prototype.flags": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            }
-        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -6058,15 +5562,6 @@
             "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
             "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
             "dev": true
-        },
-        "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
         },
         "safe-buffer": {
             "version": "5.2.1",
@@ -6114,6 +5609,12 @@
             "requires": {
                 "randombytes": "^2.1.0"
             }
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -6324,27 +5825,27 @@
             }
         },
         "tfx-cli": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.2.tgz",
-            "integrity": "sha512-//TwhDpxuog4RwbQ31fQDmzLEBIBXsBhoV+tSVHtkqlTOOTMn52eNOVkTDcsH35fttQstrNEvOFM6pCCo2jx3w==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.10.0.tgz",
+            "integrity": "sha512-8Uwtw+VMoFjEKkq2e71afvATdNPanLeYwzozibdfVKbAH93PR4hA8L7B1GAd2HCk4k0Jr1SUE9NclxQ38oN1aQ==",
             "dev": true,
             "requires": {
                 "app-root-path": "1.0.0",
                 "archiver": "2.0.3",
                 "async": "^1.4.0",
-                "azure-devops-node-api": "^8.1.1",
+                "azure-devops-node-api": "^10.2.2",
                 "clipboardy": "~1.2.3",
                 "colors": "~1.3.0",
                 "glob": "7.1.2",
                 "jju": "^1.4.0",
                 "json-in-place": "^1.0.1",
-                "jszip": "~3.1.5",
-                "lodash": "~4.17.11",
-                "minimist": "^1.1.2",
+                "jszip": "^3.7.1",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.5",
                 "mkdirp": "^0.5.1",
                 "onecolor": "^2.5.0",
                 "os-homedir": "^1.0.1",
-                "prompt": "^0.2.14",
+                "prompt": "^1.2.0",
                 "read": "^1.0.6",
                 "shelljs": "^0.5.1",
                 "tmp": "0.0.26",
@@ -6586,9 +6087,9 @@
             }
         },
         "tunnel": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true
         },
         "type-fest": {
@@ -6598,13 +6099,14 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+            "version": "1.8.6",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
+            "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
             "dev": true,
             "requires": {
-                "tunnel": "0.0.4",
-                "underscore": "1.8.3"
+                "qs": "^6.9.1",
+                "tunnel": "0.0.6",
+                "underscore": "^1.12.1"
             }
         },
         "typedarray": {
@@ -6632,9 +6134,9 @@
             }
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
             "dev": true
         },
         "util-deprecate": {
@@ -6654,28 +6156,6 @@
                 "for-each": "^0.3.3",
                 "has-symbols": "^1.0.1",
                 "object.getownpropertydescriptors": "^2.1.1"
-            }
-        },
-        "utile": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-            "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
-            "dev": true,
-            "requires": {
-                "async": "~0.2.9",
-                "deep-equal": "*",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "0.4.x",
-                "rimraf": "2.x.x"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "0.2.10",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-                    "dev": true
-                }
             }
         },
         "uuid": {
@@ -6728,32 +6208,6 @@
                 "is-symbol": "^1.0.3"
             }
         },
-        "which-collection": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-            "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-            "dev": true,
-            "requires": {
-                "is-map": "^2.0.1",
-                "is-set": "^2.0.1",
-                "is-weakmap": "^2.0.1",
-                "is-weakset": "^2.0.1"
-            }
-        },
-        "which-typed-array": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
-            "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-            "dev": true,
-            "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "es-abstract": "^1.18.5",
-                "foreach": "^2.0.5",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.7"
-            }
-        },
         "wide-align": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -6770,36 +6224,29 @@
             "dev": true
         },
         "winston": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-            "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+            "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
             "dev": true,
             "requires": {
-                "async": "0.2.x",
-                "colors": "0.6.x",
+                "async": "~1.0.0",
+                "colors": "1.0.x",
                 "cycle": "1.0.x",
                 "eyes": "0.1.x",
                 "isstream": "0.1.x",
-                "pkginfo": "0.3.x",
                 "stack-trace": "0.0.x"
             },
             "dependencies": {
                 "async": {
-                    "version": "0.2.10",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
                     "dev": true
                 },
                 "colors": {
-                    "version": "0.6.2",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                    "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-                    "dev": true
-                },
-                "pkginfo": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                    "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "mocha": "^8.3.2",
         "shelljs": "^0.8.4",
         "sync-request": "^6.1.0",
-        "tfx-cli": "^0.9.2",
+        "tfx-cli": "^0.10.0",
         "tslint": "^5.20.1",
         "typescript": "^4.2.4"
     }

--- a/pre-integ-test.pipeline.yml
+++ b/pre-integ-test.pipeline.yml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: ubuntu-16.04
+  vmImage: ubuntu-latest
 
 steps:
   - script: sleep 60

--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -21,14 +21,18 @@ async function install(release?: string) {
         throw new Error(taskLib.loc("InstallNotSupportedOnSelfHosted"));
     }
 
-    // install core system dependencies
-    const depArgs: string[] = [];
-    if (release !== undefined) {
-        depArgs.push(release);
-    }
-    let exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", depArgs);
-    if (exitCode !== 0) {
-        throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
+    let exitCode = 0;
+
+    // install core system dependencies on Linux
+    if (platform() === "linux") {
+        const depArgs: string[] = [];
+        if (release !== undefined) {
+            depArgs.push(release);
+        }
+        exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh", depArgs);
+        if (exitCode !== 0) {
+            throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
+        }
     }
 
     // install ephemeral version of MATLAB

--- a/tasks/install-matlab/v0/main.ts
+++ b/tasks/install-matlab/v0/main.ts
@@ -1,7 +1,9 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2022 The MathWorks, Inc.
 
 import * as taskLib from "azure-pipelines-task-lib/task";
 import * as toolLib from "azure-pipelines-tool-lib/tool";
+import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import {platform} from "./utils";
 
@@ -43,6 +45,15 @@ async function install(release?: string) {
     exitCode = await curlsh("https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh", installArgs);
     if (exitCode !== 0) {
         throw new Error(taskLib.loc("FailedToExecuteInstallScript", exitCode));
+    }
+
+    // prepend MATLAB to path
+    let root: string;
+    try {
+        root = fs.readFileSync(path.join(os.tmpdir(), "ephemeral_matlab_root")).toString();
+        toolLib.prependPath(path.join(root, "bin"));
+    } catch (err: any) {
+        throw new Error(taskLib.loc("FailedToAddToPath", err.message));
     }
 }
 

--- a/tasks/install-matlab/v0/task.json
+++ b/tasks/install-matlab/v0/task.json
@@ -31,6 +31,7 @@
     "messages": {
         "InstallNotSupportedOnSelfHosted": "Install MATLAB task is not supported on self-hosted agents. To install MATLAB on this machine, use the standard installer.",
         "FailedToDownloadInstallScript": "Failed to download install script: %s",
-        "FailedToExecuteInstallScript": "Failed to execute install script. Exited with code '%s'."
+        "FailedToExecuteInstallScript": "Failed to execute install script. Exited with code '%s'.",
+        "FailedToAddToPath": "Failed to add MATLAB to system path: %s"
     }
 }

--- a/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteLinux.ts
@@ -1,7 +1,9 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2022 The MathWorks, Inc.
 
 import ma = require("azure-pipelines-task-lib/mock-answer");
 import mr = require("azure-pipelines-task-lib/mock-run");
+import * as fs from "fs";
+import * as os from "os";
 import path = require("path");
 
 const tp = path.join(__dirname, "..", "main.js");
@@ -11,6 +13,9 @@ tr.setInput("release", "R2020a");
 
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
+const matlabRoot = "path/to/matlab";
+fs.writeFileSync(path.join(os.tmpdir(), "ephemeral_matlab_root"), matlabRoot);
+
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
         if (url === "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh") {
@@ -19,6 +24,11 @@ tr.registerMock("azure-pipelines-tool-lib/tool", {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");
+        }
+    },
+    prependPath(toolPath: string) {
+        if (toolPath !== path.join(matlabRoot, "bin")) {
+            throw new Error(`Unexpected path: ${toolPath}`);
         }
     },
 });

--- a/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
@@ -1,7 +1,9 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2022 The MathWorks, Inc.
 
 import ma = require("azure-pipelines-task-lib/mock-answer");
 import mr = require("azure-pipelines-task-lib/mock-run");
+import * as fs from "fs";
+import * as os from "os";
 import path = require("path");
 
 const tp = path.join(__dirname, "..", "main.js");
@@ -11,12 +13,20 @@ tr.setInput("release", "R2020a");
 
 process.env.SYSTEM_SERVERTYPE = "hosted";
 
+const matlabRoot = "C:\\path\\to\\matlab";
+fs.writeFileSync(path.join(os.tmpdir(), "ephemeral_matlab_root"), matlabRoot);
+
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
         if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");
+        }
+    },
+    prependPath(toolPath: string) {
+        if (toolPath !== path.join(matlabRoot, "bin")) {
+            throw new Error(`Unexpected path: ${toolPath}`);
         }
     },
 });

--- a/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
+++ b/tasks/install-matlab/v0/test/downloadAndExecuteWindows.ts
@@ -13,9 +13,7 @@ process.env.SYSTEM_SERVERTYPE = "hosted";
 
 tr.registerMock("azure-pipelines-tool-lib/tool", {
     downloadTool(url: string) {
-        if (url === "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh") {
-            return "install.sh";
-        } else if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
+        if (url === "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh") {
             return "ci-install.sh";
         } else {
             throw new Error("Incorrect URL");
@@ -35,10 +33,6 @@ const a: ma.TaskLibAnswers = {
         "bash.exe": true,
     },
     exec: {
-        "bash.exe install.sh R2020a": {
-            code: 0,
-            stdout: "Installed MATLAB",
-        },
         "bash.exe ci-install.sh --release R2020a": {
             code: 0,
             stdout: "Installed MATLAB",

--- a/tasks/install-matlab/v0/test/suite.ts
+++ b/tasks/install-matlab/v0/test/suite.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2022 The MathWorks, Inc.
 
 import * as assert from "assert";
 import * as mt from "azure-pipelines-task-lib/mock-test";


### PR DESCRIPTION
This change adds limited, undocumented, Windows and macOS support for GitHub-hosted runners. Only the core MATLAB and Simulink products (no toolboxes) will be available for these platforms at this time.