### PR TITLE
Removing Ubuntu 16.04 from public docs

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -76,7 +76,7 @@ For example, install MATLAB R2021a on a Microsoft-hosted agent, and then use the
 
 ```YAML
 pool:
-  vmImage: Ubuntu 16.04
+  vmImage: ubuntu-20.04
 steps:
   - task: InstallMATLAB@0
     inputs:

--- a/overview.md
+++ b/overview.md
@@ -76,7 +76,7 @@ For example, install MATLAB R2021a on a Microsoft-hosted agent, and then use the
 
 ```YAML
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 steps:
   - task: InstallMATLAB@0
     inputs:


### PR DESCRIPTION
Replacing examples with Ubuntu 16.04 with Ubuntu 20.04