### PR TITLE
Add privacy policy link

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -41,6 +41,9 @@
         },
         "support": {
             "uri": "mailto:continuous-integration@mathworks.com"
+        },
+        "privacypolicy": {
+            "uri": "https://www.mathworks.com/company/aboutus/policies_statements/privacy-policy.html"
         }
     },
     "repository": {


### PR DESCRIPTION
In order to qualify as a "Top Publisher" we need to include a link to our privacy policy.