### PR TITLE
Fix macos cache bug

### DIFF
--- a/tasks/install-matlab/v1/src/matlab.ts
+++ b/tasks/install-matlab/v1/src/matlab.ts
@@ -21,22 +21,21 @@ export async function makeToolcacheDir(release: Release, platform: string): Prom
     } else {
         if (platform === "win32") {
             toolpath = await windowsHostedToolpath(release).catch(async () => {
-                return await defaultToolpath(release, platform);
+                return await defaultToolpath(release);
             });
         } else {
-            toolpath = await defaultToolpath(release, platform);
+            toolpath = await defaultToolpath(release);
         }
+    }
+    if (platform === "darwin") {
+        toolpath = toolpath + "/MATLAB.app";
     }
     return [toolpath, alreadyExists];
 }
 
-export async function defaultToolpath(release: Release, platform: string): Promise<string> {
+export async function defaultToolpath(release: Release): Promise<string> {
     fs.writeFileSync(".keep", "");
-    let toolpath = await toolLib.cacheFile(".keep", ".keep", "MATLAB", release.version);
-    if (platform === "darwin") {
-        toolpath = toolpath + "/MATLAB.app";
-    }
-    return toolpath;
+    return await toolLib.cacheFile(".keep", ".keep", "MATLAB", release.version);
 }
 
 async function windowsHostedToolpath(release: Release): Promise<string> {

--- a/tasks/install-matlab/v1/test/matlab.test.ts
+++ b/tasks/install-matlab/v1/test/matlab.test.ts
@@ -69,6 +69,16 @@ export default function suite() {
         assert(!alreadyExists);
       });
 
+      it("finds existing cache and returns default path for mac", async () => {
+        platform = "darwin";
+        stubFindLocalTool.callsFake((tool, ver) => {
+          return defaultToolcacheLoc;
+        });
+        const [matlabPath, alreadyExists] = await matlab.makeToolcacheDir(releaseInfo, platform);
+        assert(matlabPath === path.join(defaultToolcacheLoc, "MATLAB.app"));
+        assert(alreadyExists);
+      });
+
       describe("windows performance workaround", () => {
         let stubGetVariable: sinon.SinonStub;
         let stubGetAgentMode: sinon.SinonStub;


### PR DESCRIPTION
There is a bug where if macos is found in toolcache, it does not return the correct path because the logic is in a function that is only called when it is not in the cache