### PR TITLE
Set resource path when testing matlab.ts

### DIFF
--- a/tasks/run-matlab-command/v1/test/matlab.test.ts
+++ b/tasks/run-matlab-command/v1/test/matlab.test.ts
@@ -38,6 +38,7 @@ export default function suite() {
                         },
                     };
                 });
+                taskLib.setResourcePath(path.join( __dirname, "..", "task.json"));
             });
 
             afterEach(() => {


### PR DESCRIPTION
Attempting to fix these warnings that appear in Azure during the build-test-publish job.

<img width="617" alt="Screenshot 2024-04-19 at 3 08 35 PM" src="https://github.com/mathworks/matlab-azure-devops-extension/assets/34887852/5e0954c7-70f7-462c-8d19-c01e2fe97e99">
