### PR TITLE
Self hosted support

### DIFF
--- a/tasks/install-matlab/v1/src/matlab.ts
+++ b/tasks/install-matlab/v1/src/matlab.ts
@@ -145,7 +145,10 @@ export async function setupBatch(platform: string, architecture: string) {
         throw new Error("Failed to add MATLAB to system path.");
     }
     if (platform !== "win32") {
-        const exitCode = await taskLib.exec("chmod", ["+x", path.join(matlabBatchPath, "matlab-batch" + matlabBatchExt)]);
+        const exitCode = await taskLib.exec(
+            "chmod",
+            ["+x", path.join(matlabBatchPath, "matlab-batch" + matlabBatchExt)],
+        );
         if (exitCode !== 0) {
             return Promise.reject(Error("Unable to add execute permissions to matlab-batch binary."));
         }

--- a/tasks/install-matlab/v1/src/matlab.ts
+++ b/tasks/install-matlab/v1/src/matlab.ts
@@ -144,11 +144,12 @@ export async function setupBatch(platform: string, architecture: string) {
     } catch (err: any) {
         throw new Error("Failed to add MATLAB to system path.");
     }
-    const exitCode = await taskLib.exec("chmod", ["+x", path.join(matlabBatchPath, "matlab-batch" + matlabBatchExt)]);
-    if (exitCode !== 0) {
-        return Promise.reject(Error("Unable to add execute permissions to matlab-batch binary."));
+    if (platform !== "win32") {
+        const exitCode = await taskLib.exec("chmod", ["+x", path.join(matlabBatchPath, "matlab-batch" + matlabBatchExt)]);
+        if (exitCode !== 0) {
+            return Promise.reject(Error("Unable to add execute permissions to matlab-batch binary."));
+        }
     }
-    return;
 }
 
 export async function installSystemDependencies(platform: string, architecture: string, release: string) {

--- a/tasks/run-matlab-command/v1/matlab.ts
+++ b/tasks/run-matlab-command/v1/matlab.ts
@@ -36,7 +36,7 @@ export async function runCommand(command: string, platform: string, architecture
 }
 
 export function getRunMATLABCommandScriptPath(platform: string, architecture: string): string {
-    if (architecture !== "x64") {
+    if (architecture !== "x64" && !(platform === "darwin" && architecture === "arm64")) {
         const msg = `This task is not supported on ${platform} runners using the ${architecture} architecture.`;
         throw new Error(msg);
     }
@@ -49,7 +49,11 @@ export function getRunMATLABCommandScriptPath(platform: string, architecture: st
             break;
         case "darwin":
             ext = "";
-            platformDir = "maci64";
+            if (architecture === "x64") {
+                platformDir = "maci64";
+            } else {
+                platformDir = "maca64";
+            }
             break;
         case "linux":
             ext = "";

--- a/tasks/run-matlab-command/v1/test/matlab.test.ts
+++ b/tasks/run-matlab-command/v1/test/matlab.test.ts
@@ -92,18 +92,18 @@ export default function suite() {
         });
 
         describe("ci bin helper path", () => {
-            const testBin = (platform: string, subdirectory: string, ext: string) => {
-                it(`considers the appropriate rmc bin on ${platform}`, () => {
-                    const architecture = "x64";
+            const testBin = (platform: string, architecture: string, subdirectory: string, ext: string) => {
+                it(`considers the appropriate rmc bin on ${platform} ${architecture}`, () => {
                     const p = matlab.getRunMATLABCommandScriptPath(platform, architecture);
                     assert(path.extname(p) === ext);
                     assert(p.includes(subdirectory));
                 });
             };
 
-            testBin("linux", "glnxa64", "");
-            testBin("win32", "win64", ".exe");
-            testBin("darwin", "maci64", "");
+            testBin("linux", "x64", "glnxa64", "");
+            testBin("win32", "x64", "win64", ".exe");
+            testBin("darwin", "x64", "maci64", "");
+            testBin("darwin", "arm64", "maca64", "");
 
             it("errors on unsupported platform", () => {
                 assert.throws(() => matlab.getRunMATLABCommandScriptPath("sunos", "x64"));


### PR DESCRIPTION
Addressing the call to `chmod` on Windows, and adding ARM Macs as a supported platform / architecture pair in run-matlab-command.