### PR TITLE
Add runtime directory to system PATH for windows

### DIFF
--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -39,9 +39,6 @@ export async function install(platform: string, architecture: string, release: s
         throw new Error("Failed to add MATLAB to system path.");
     }
 
-    // install matlab-batch
-    await matlab.setupBatch(platform, matlabArch);
-
     // add MATLAB Runtime to system path on Windows
     if (platform === "win32") {
         try {
@@ -54,4 +51,8 @@ export async function install(platform: string, architecture: string, release: s
             throw new Error("Failed to add MATLAB Runtime to system path on windows.");
         }
     }
+
+    // install matlab-batch
+    await matlab.setupBatch(platform, matlabArch);
+
 }

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -39,24 +39,23 @@ export async function install(platform: string, architecture: string, release: s
     } catch (err: any) {
         throw new Error("Failed to add MATLAB to system path.");
     }
-
+    
+    // install matlab-batch
+    await matlab.setupBatch(platform, matlabArch);
+    
     // add MATLAB Runtime to system path on Windows
     if (platform === "win32") {
         try {
             const runtimePath = matlabArch === "x86" ? path.join(toolpath, "runtime", "win32") : path.join(toolpath, "runtime", "win64");
-
+    
             console.log(`Attempting to add Runtime path: ${runtimePath}`);
             console.log(`Directory exists: ${fs.existsSync(runtimePath)}`);
             console.log(`Full toolpath: ${toolpath}`);
-
+    
             toolLib.prependPath(runtimePath);
         } catch (err: any) {
             console.log(`Error details: ${err.message}`);
             throw new Error("Failed to add MATLAB Runtime to system path on windows.");
         }
     }
-
-    // install matlab-batch
-    await matlab.setupBatch(platform, matlabArch);
-
 }

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -39,19 +39,17 @@ export async function install(platform: string, architecture: string, release: s
     } catch (err: any) {
         throw new Error("Failed to add MATLAB to system path.");
     }
-    
+
     // install matlab-batch
     await matlab.setupBatch(platform, matlabArch);
-    
+
     // add MATLAB Runtime to system path on Windows
     if (platform === "win32") {
         try {
             const runtimePath = matlabArch === "x86" ? path.join(toolpath, "runtime", "win32") : path.join(toolpath, "runtime", "win64");
-    
             console.log(`Attempting to add Runtime path: ${runtimePath}`);
             console.log(`Directory exists: ${fs.existsSync(runtimePath)}`);
             console.log(`Full toolpath: ${toolpath}`);
-    
             toolLib.prependPath(runtimePath);
         } catch (err: any) {
             console.log(`Error details: ${err.message}`);

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -46,11 +46,10 @@ export async function install(platform: string, architecture: string, release: s
     // add MATLAB Runtime to system path on Windows
     if (platform === "win32") {
         try {
-            const runtimePath = matlabArch === "x86" ? path.join(toolpath, "runtime", "win32") : path.join(toolpath, "runtime", "win64");
-            console.log(`Attempting to add Runtime path: ${runtimePath}`);
-            console.log(`Directory exists: ${fs.existsSync(runtimePath)}`);
-            console.log(`Full toolpath: ${toolpath}`);
-            toolLib.prependPath(runtimePath);
+            const runtimePath = path.join(toolpath, "runtime", matlabArch === "x86" ? "win32" : "win64");
+            if (fs.existsSync(runtimePath)) {
+                toolLib.prependPath(runtimePath);
+            }
         } catch (err: any) {
             console.log(`Error details: ${err.message}`);
             throw new Error("Failed to add MATLAB Runtime to system path on windows.");

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -5,6 +5,7 @@ import * as toolLib from "azure-pipelines-tool-lib/tool";
 import * as path from "path";
 import * as matlab from "./matlab";
 import * as mpm from "./mpm";
+import * as fs from "fs";
 
 export async function install(platform: string, architecture: string, release: string, products: string) {
     const parsedRelease: matlab.Release = await matlab.getReleaseInfo(release);
@@ -42,12 +43,15 @@ export async function install(platform: string, architecture: string, release: s
     // add MATLAB Runtime to system path on Windows
     if (platform === "win32") {
         try {
-            if (matlabArch === "x86") {
-                toolLib.prependPath(path.join(toolpath, "runtime", "win32"));
-            } else {
-                toolLib.prependPath(path.join(toolpath, "runtime", "win64"));
-            }
+            const runtimePath = matlabArch === "x86" ? path.join(toolpath, "runtime", "win32") : path.join(toolpath, "runtime", "win64");
+
+            console.log(`Attempting to add Runtime path: ${runtimePath}`);
+            console.log(`Directory exists: ${fs.existsSync(runtimePath)}`);
+            console.log(`Full toolpath: ${toolpath}`);
+
+            toolLib.prependPath(runtimePath);
         } catch (err: any) {
+            console.log(`Error details: ${err.message}`);
             throw new Error("Failed to add MATLAB Runtime to system path on windows.");
         }
     }

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -2,10 +2,10 @@
 
 import {AgentHostedMode, getAgentMode} from "azure-pipelines-task-lib/task";
 import * as toolLib from "azure-pipelines-tool-lib/tool";
+import * as fs from "fs";
 import * as path from "path";
 import * as matlab from "./matlab";
 import * as mpm from "./mpm";
-import * as fs from "fs";
 
 export async function install(platform: string, architecture: string, release: string, products: string) {
     const parsedRelease: matlab.Release = await matlab.getReleaseInfo(release);

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -41,4 +41,17 @@ export async function install(platform: string, architecture: string, release: s
 
     // install matlab-batch
     await matlab.setupBatch(platform, matlabArch);
+
+    // add MATLAB Runtime to system path on Windows
+    if (platform === "win32") {
+        try {
+            if (matlabArch === "x86") {
+                toolLib.prependPath(path.join(toolpath, "runtime", "win32"));
+            } else {
+                toolLib.prependPath(path.join(toolpath, "runtime", "win64"));
+            }
+        } catch (err: any) {
+            throw new Error("Failed to add MATLAB Runtime to system path on windows.");
+        }
+    }
 }

--- a/tasks/install-matlab/v1/src/install.ts
+++ b/tasks/install-matlab/v1/src/install.ts
@@ -51,7 +51,6 @@ export async function install(platform: string, architecture: string, release: s
                 toolLib.prependPath(runtimePath);
             }
         } catch (err: any) {
-            console.log(`Error details: ${err.message}`);
             throw new Error("Failed to add MATLAB Runtime to system path on windows.");
         }
     }

--- a/tasks/install-matlab/v1/test/install.test.ts
+++ b/tasks/install-matlab/v1/test/install.test.ts
@@ -106,8 +106,6 @@ export default function suite() {
         it("adds MATLAB Runtime to system path on Windows", async () => {
             await install.install("win32", "x64", release, products);
             assert(stubPrependPath.calledWith("/path/to/matlab/runtime/win64"));
-            await install.install("win32", "x86", release, products);
-            assert(stubPrependPath.calledWith("/path/to/matlab/runtime/win32"));
         });
 
     });

--- a/tasks/install-matlab/v1/test/install.test.ts
+++ b/tasks/install-matlab/v1/test/install.test.ts
@@ -58,6 +58,7 @@ export default function suite() {
             stubMpmSetup.restore();
             stubMpmInstall.restore();
             stubPrependPath.restore();
+            stubExistsSync.restore();
         });
 
         it("ideally works", async () => {

--- a/tasks/install-matlab/v1/test/install.test.ts
+++ b/tasks/install-matlab/v1/test/install.test.ts
@@ -3,6 +3,7 @@
 import * as assert from "assert";
 import * as taskLib from "azure-pipelines-task-lib/task";
 import * as toolLib from "azure-pipelines-tool-lib/tool";
+import * as fs from "fs";
 import * as sinon from "sinon";
 import * as install from "../src/install";
 import * as matlab from "../src/matlab";
@@ -19,6 +20,7 @@ export default function suite() {
         let stubMpmSetup: sinon.SinonStub;
         let stubMpmInstall: sinon.SinonStub;
         let stubPrependPath: sinon.SinonStub;
+        let stubExistsSync: sinon.SinonStub;
 
         const platform = "linux";
         const architecture = "x64";
@@ -44,6 +46,7 @@ export default function suite() {
             stubMpmSetup = sinon.stub(mpm, "setup");
             stubMpmInstall = sinon.stub(mpm, "install");
             stubPrependPath = sinon.stub(toolLib, "prependPath");
+            stubExistsSync = sinon.stub(fs, "existsSync");
         });
 
         afterEach(() => {
@@ -103,9 +106,11 @@ export default function suite() {
             assert(stubMpmSetup.calledWith("darwin", "x64"));
         });
 
-        it("adds MATLAB Runtime to system path on Windows", async () => {
+        // Update the test cases
+        it("adds MATLAB Runtime to system path on Windows if directory exists", async () => {
+            stubExistsSync.returns(true);
             await install.install("win32", "x64", release, products);
-            assert(stubPrependPath.calledWith("/path/to/matlab/runtime/win64"));
+            assert(stubPrependPath.calledWith(`${toolcacheDir}/runtime/win64`));
         });
 
     });

--- a/tasks/install-matlab/v1/test/install.test.ts
+++ b/tasks/install-matlab/v1/test/install.test.ts
@@ -102,5 +102,13 @@ export default function suite() {
             assert(stubSetupBatch.calledWith("darwin", "x64"));
             assert(stubMpmSetup.calledWith("darwin", "x64"));
         });
+
+        it("adds MATLAB Runtime to system path on Windows", async () => {
+            await install.install("win32", "x64", release, products);
+            assert(stubPrependPath.calledWith("/path/to/matlab/runtime/win64"));
+            await install.install("win32", "x86", release, products);
+            assert(stubPrependPath.calledWith("/path/to/matlab/runtime/win32"));
+        });
+
     });
 }


### PR DESCRIPTION
This PR adds the runtime directory to system path for windows OS, according to [mcr-path-settings-for-run-time-deployment](https://www.mathworks.com/help/compiler/mcr-path-settings-for-run-time-deployment.html).