### PR TITLE
Bugfix if matlab-batch already exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -727,9 +727,9 @@
             }
         },
         "node_modules/archiver-utils/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/archiver-utils/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -786,9 +786,9 @@
             }
         },
         "node_modules/archiver/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -819,9 +819,9 @@
             }
         },
         "node_modules/archiver/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1014,9 +1014,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1696,9 +1696,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3340,9 +3340,10 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/lodash/-/lodash-4.18.0.tgz",
+            "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+            "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
             "dev": true,
             "license": "MIT"
         },
@@ -3477,9 +3478,9 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "5.1.9",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3513,9 +3514,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "10.7.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
-            "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
+            "version": "10.8.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3688,9 +3689,9 @@
             }
         },
         "node_modules/nyc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3760,9 +3761,9 @@
             }
         },
         "node_modules/nyc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4105,9 +4106,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4449,9 +4450,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4482,9 +4483,9 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4676,9 +4677,9 @@
             }
         },
         "node_modules/shelljs/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4709,9 +4710,9 @@
             }
         },
         "node_modules/shelljs/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5117,9 +5118,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5150,9 +5151,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5202,9 +5203,9 @@
             }
         },
         "node_modules/tfx-cli/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5232,9 +5233,9 @@
             }
         },
         "node_modules/tfx-cli/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5412,9 +5413,9 @@
             }
         },
         "node_modules/tslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5455,9 +5456,9 @@
             "license": "MIT"
         },
         "node_modules/tslint/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -5521,9 +5522,9 @@
             }
         },
         "node_modules/tslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5754,9 +5755,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
             "name": "matlab-azure-devops-extension",
             "version": "1.0.0",
             "devDependencies": {
-                "@types/mocha": "^8.2.2",
+                "@types/mocha": "^8.2.3",
                 "@types/node": "^22.7.5",
                 "@types/shelljs": "^0.8.15",
                 "@types/sinon": "^10.0.13",
                 "@types/uuid": "^9.0.8",
-                "mocha": "^10.0.0",
+                "mocha": "^10.8.2",
                 "nyc": "^15.1.0",
                 "shelljs": "^0.8.5",
                 "sinon": "^15.0.1",
@@ -728,7 +728,7 @@
         },
         "node_modules/archiver-utils/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -761,7 +761,7 @@
         },
         "node_modules/archiver-utils/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -787,7 +787,7 @@
         },
         "node_modules/archiver/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -820,7 +820,7 @@
         },
         "node_modules/archiver/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -1015,7 +1015,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "2.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
             "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "license": "MIT",
@@ -1697,7 +1697,7 @@
         },
         "node_modules/diff": {
             "version": "5.2.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/diff/-/diff-5.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
             "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -2298,7 +2298,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
             "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3341,7 +3341,7 @@
         },
         "node_modules/lodash": {
             "version": "4.18.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/lodash/-/lodash-4.18.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
             "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
             "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
             "dev": true,
@@ -3479,7 +3479,7 @@
         },
         "node_modules/minimatch": {
             "version": "5.1.9",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-5.1.9.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
             "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
@@ -3515,7 +3515,7 @@
         },
         "node_modules/mocha": {
             "version": "10.8.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mocha/-/mocha-10.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
             "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
             "dev": true,
             "license": "MIT",
@@ -3690,7 +3690,7 @@
         },
         "node_modules/nyc/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -3762,7 +3762,7 @@
         },
         "node_modules/nyc/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -4107,7 +4107,7 @@
         },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
@@ -4451,7 +4451,7 @@
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -4484,7 +4484,7 @@
         },
         "node_modules/rimraf/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -4678,7 +4678,7 @@
         },
         "node_modules/shelljs/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -4711,7 +4711,7 @@
         },
         "node_modules/shelljs/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -5119,7 +5119,7 @@
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -5152,7 +5152,7 @@
         },
         "node_modules/test-exclude/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -5204,7 +5204,7 @@
         },
         "node_modules/tfx-cli/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -5234,7 +5234,7 @@
         },
         "node_modules/tfx-cli/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -5414,7 +5414,7 @@
         },
         "node_modules/tslint/node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
@@ -5457,7 +5457,7 @@
         },
         "node_modules/tslint/node_modules/diff": {
             "version": "4.0.4",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/diff/-/diff-4.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
             "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -5523,7 +5523,7 @@
         },
         "node_modules/tslint/node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -5756,7 +5756,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
             "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
         "preparePackage": "node ./scripts/preparePackage.js"
     },
     "devDependencies": {
-        "@types/mocha": "^8.2.2",
+        "@types/mocha": "^8.2.3",
         "@types/node": "^22.7.5",
         "@types/shelljs": "^0.8.15",
         "@types/sinon": "^10.0.13",
         "@types/uuid": "^9.0.8",
-        "mocha": "^10.0.0",
+        "mocha": "^10.8.2",
         "nyc": "^15.1.0",
         "shelljs": "^0.8.5",
         "sinon": "^15.0.1",

--- a/tasks/install-matlab/v0/package-lock.json
+++ b/tasks/install-matlab/v0/package-lock.json
@@ -10,13 +10,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.8"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -29,7 +29,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -38,7 +38,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -98,38 +98,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -142,29 +112,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -175,7 +135,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -185,7 +145,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -197,7 +157,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "license": "MIT",
             "dependencies": {
@@ -210,7 +170,7 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/call-bound/-/call-bound-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
@@ -232,7 +192,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -263,7 +223,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "license": "MIT",
             "dependencies": {
@@ -277,7 +237,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "license": "MIT",
             "engines": {
@@ -286,7 +246,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "license": "MIT",
             "engines": {
@@ -295,7 +255,7 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "license": "MIT",
             "dependencies": {
@@ -307,7 +267,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -330,7 +290,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -346,7 +306,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -355,7 +315,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                 }
             }
         },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
-        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -402,7 +356,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "license": "MIT",
             "dependencies": {
@@ -426,7 +380,7 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "license": "MIT",
             "dependencies": {
@@ -439,7 +393,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -449,30 +403,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -482,21 +415,9 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "license": "MIT",
             "engines": {
@@ -508,7 +429,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
             "engines": {
@@ -545,57 +466,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -604,7 +484,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -616,7 +496,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -625,7 +505,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -637,13 +517,13 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "license": "MIT",
             "engines": {
@@ -652,13 +532,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -667,7 +547,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -701,7 +581,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -709,9 +589,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -740,7 +620,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -752,7 +632,7 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/object-inspect/-/object-inspect-1.13.4.tgz",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
@@ -762,18 +642,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -786,33 +657,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -835,7 +691,7 @@
         },
         "node_modules/qs": {
             "version": "6.15.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/qs/-/qs-6.15.0.tgz",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
             "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -850,7 +706,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -868,37 +724,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -908,7 +736,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -955,7 +783,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -967,7 +795,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -975,25 +803,21 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel/-/side-channel-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "license": "MIT",
             "dependencies": {
@@ -1012,7 +836,7 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "license": "MIT",
             "dependencies": {
@@ -1028,7 +852,7 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
             "dependencies": {
@@ -1046,7 +870,7 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
             "dependencies": {
@@ -1065,34 +889,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1133,7 +945,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1161,7 +973,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1173,12 +985,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/install-matlab/v0/package-lock.json
+++ b/tasks/install-matlab/v0/package-lock.json
@@ -14,6 +14,41 @@
                 "azure-pipelines-tool-lib": "^2.0.8"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -78,14 +113,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -93,18 +128,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -114,26 +174,48 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
-                "es-define-property": "^1.0.0",
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
                 "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -147,6 +229,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -165,42 +261,108 @@
                 }
             }
         },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "license": "MIT",
             "dependencies": {
-                "es-define-property": "^1.0.0",
+                "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
+                "gopd": "^1.2.0"
             },
             "engines": {
                 "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "version": "1.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -239,22 +401,52 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+            "version": "1.3.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "license": "MIT",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/glob": {
@@ -278,10 +470,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -291,33 +495,9 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -327,9 +507,9 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -361,6 +541,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
             }
         },
         "node_modules/inflight": {
@@ -404,6 +593,91 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -423,6 +697,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -455,10 +738,22 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+            "version": "1.13.4",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -476,6 +771,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -485,11 +795,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -503,12 +834,12 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "version": "6.15.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -516,6 +847,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -545,6 +896,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -569,21 +953,25 @@
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
         },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
+                "shebang-regex": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.4"
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shelljs": {
@@ -604,21 +992,90 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -631,6 +1088,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -663,9 +1132,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -688,6 +1157,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/install-matlab/v0/package.json
+++ b/tasks/install-matlab/v0/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.8"
     }
 }

--- a/tasks/install-matlab/v1/package-lock.json
+++ b/tasks/install-matlab/v1/package-lock.json
@@ -14,6 +14,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -78,14 +113,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -93,18 +128,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -114,13 +174,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -157,6 +229,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -217,6 +303,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -291,6 +437,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -312,10 +470,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -373,6 +543,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -414,6 +593,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -421,6 +648,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -442,6 +697,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -474,6 +738,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -495,6 +771,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -504,11 +795,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -535,6 +847,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -564,6 +896,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -587,6 +952,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -677,6 +1063,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -687,6 +1088,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -719,9 +1132,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -744,6 +1157,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/install-matlab/v1/package-lock.json
+++ b/tasks/install-matlab/v1/package-lock.json
@@ -10,13 +10,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -29,7 +29,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -38,7 +38,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -98,38 +98,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -142,29 +112,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -175,7 +135,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -185,7 +145,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -232,7 +192,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -307,7 +267,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -330,7 +290,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -346,7 +306,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -355,7 +315,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -384,12 +344,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -439,7 +393,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -449,30 +403,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -480,18 +413,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -545,57 +466,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -604,7 +484,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -616,7 +496,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -625,7 +505,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -637,7 +517,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -652,13 +532,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -667,7 +547,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -701,7 +581,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -709,9 +589,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -740,7 +620,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -762,18 +642,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -786,33 +657,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -850,7 +706,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -868,37 +724,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -908,7 +736,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -955,7 +783,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -967,7 +795,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -975,20 +803,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1065,34 +889,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1133,7 +945,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1161,7 +973,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1173,12 +985,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/install-matlab/v1/package.json
+++ b/tasks/install-matlab/v1/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }

--- a/tasks/install-matlab/v1/src/matlab.ts
+++ b/tasks/install-matlab/v1/src/matlab.ts
@@ -148,21 +148,29 @@ export async function setupBatch(platform: string, architecture: string) {
             return Promise.reject(Error(`This task is not supported on ${platform} runners.`));
     }
 
-    const tempPath = await downloadToolWithRetries(matlabBatchUrl, `matlab-batch${matlabBatchExt}`);
-    const matlabBatchPath = await toolLib.cacheFile(tempPath, `matlab-batch${matlabBatchExt}`, "matlab-batch", "1.0.0");
+    const matlabBatchBin = `matlab-batch${matlabBatchExt}`;
+    const tempDirectory = taskLib.getVariable("Agent.TempDirectory");
+    if (!tempDirectory) {
+        throw new Error("Agent.TempDirectory is not set");
+    }
+    const matlabBatchDir = path.join(tempDirectory, "matlab-batch");
+    const matlabBatchFile = path.join(matlabBatchDir, matlabBatchBin);
+
+    if (!fs.existsSync(matlabBatchFile)) {
+        fs.mkdirSync(matlabBatchDir, {recursive: true});
+        await downloadToolWithRetries(matlabBatchUrl, matlabBatchFile);
+        if (platform !== "win32") {
+            const exitCode = await taskLib.exec("chmod", ["+x", matlabBatchFile]);
+            if (exitCode !== 0) {
+                return Promise.reject(Error("Unable to add execute permissions to matlab-batch binary."));
+            }
+        }
+    }
+
     try {
-        toolLib.prependPath(matlabBatchPath);
+        toolLib.prependPath(matlabBatchDir);
     } catch (err: any) {
         throw new Error("Failed to add MATLAB to system path.");
-    }
-    if (platform !== "win32") {
-        const exitCode = await taskLib.exec(
-            "chmod",
-            ["+x", path.join(matlabBatchPath, "matlab-batch" + matlabBatchExt)],
-        );
-        if (exitCode !== 0) {
-            return Promise.reject(Error("Unable to add execute permissions to matlab-batch binary."));
-        }
     }
 }
 

--- a/tasks/install-matlab/v1/test/matlab.test.ts
+++ b/tasks/install-matlab/v1/test/matlab.test.ts
@@ -164,21 +164,20 @@ export default function suite() {
 
     describe("setupBatch", () => {
       let stubGetVariable: sinon.SinonStub;
-      let stubCacheFile: sinon.SinonStub;
+      let stubExistsSync: sinon.SinonStub;
+      let stubMkdirSync: sinon.SinonStub;
       let stubDownloadTool: sinon.SinonStub;
       let stubPrependPath: sinon.SinonStub;
       let stubExec: sinon.SinonStub;
       let platform: string;
       let architecture: string;
-      const matlabBatchPath = "/path/to/downloaded/matlab-batch";
+      const tempDir = "/home/agent/_tmp";
 
       beforeEach(() => {
         stubGetVariable = sinon.stub(taskLib, "getVariable");
         stubGetVariable.callsFake((v) => {
-          if (v === "Agent.ToolsDirectory") {
-            return "C:\\Program Files\\hostedtoolcache\\MATLAB\\r2022b";
-          } else if (v === "Agent.TempDirectory") {
-            return "/home/agent/_tmp";
+          if (v === "Agent.TempDirectory") {
+            return tempDir;
           }
           return "";
         });
@@ -186,13 +185,12 @@ export default function suite() {
         stubExec.callsFake((tool, args) => {
           return Promise.resolve(0);
         });
-        stubCacheFile = sinon.stub(toolLib, "cacheFile");
-        stubCacheFile.callsFake((srcFile, desFile, tool, ver) => {
-          return Promise.resolve(matlabBatchPath);
-        });
+        stubExistsSync = sinon.stub(fs, "existsSync");
+        stubExistsSync.returns(false);
+        stubMkdirSync = sinon.stub(fs, "mkdirSync");
         stubDownloadTool = sinon.stub(toolLib, "downloadToolWithRetries");
         stubDownloadTool.callsFake((url, name) => {
-          return Promise.resolve(matlabBatchPath);
+          return Promise.resolve(name);
         });
         stubPrependPath = sinon.stub(toolLib, "prependPath");
         platform = "linux";
@@ -202,7 +200,8 @@ export default function suite() {
       afterEach(() => {
         stubGetVariable.restore();
         stubExec.restore();
-        stubCacheFile.restore();
+        stubExistsSync.restore();
+        stubMkdirSync.restore();
         stubDownloadTool.restore();
         stubPrependPath.restore();
       });
@@ -236,6 +235,13 @@ export default function suite() {
                 await matlab.setupBatch(platform, architecture);
             });
         });
+      });
+
+      it("setupBatch skips download when matlab-batch already exists", async () => {
+        stubExistsSync.returns(true);
+        await matlab.setupBatch(platform, architecture);
+        assert(stubPrependPath.calledWith(path.join(tempDir, "matlab-batch")));
+        assert(stubDownloadTool.notCalled);
       });
 
       it("setupBatch rejects on unsupported platforms", async () => {

--- a/tasks/run-matlab-build/v0/package-lock.json
+++ b/tasks/run-matlab-build/v0/package-lock.json
@@ -15,6 +15,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -79,14 +114,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -94,18 +129,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -115,13 +175,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -158,6 +230,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -218,6 +304,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -292,6 +438,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -313,10 +471,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -374,6 +544,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -415,6 +594,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -422,6 +649,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -443,6 +698,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -475,6 +739,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -496,6 +772,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -505,11 +796,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -536,6 +848,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -565,6 +897,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -588,6 +953,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -678,6 +1064,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -688,6 +1089,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -720,9 +1133,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -745,6 +1158,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-build/v0/package-lock.json
+++ b/tasks/run-matlab-build/v0/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -30,7 +30,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -39,7 +39,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -99,38 +99,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -143,29 +113,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -176,7 +136,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -186,7 +146,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -233,7 +193,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -308,7 +268,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -331,7 +291,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -347,7 +307,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -356,7 +316,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -440,7 +394,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -450,30 +404,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -481,18 +414,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -546,57 +467,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -605,7 +485,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +497,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -626,7 +506,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -638,7 +518,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -653,13 +533,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -668,7 +548,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -702,7 +582,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -710,9 +590,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -741,7 +621,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -763,18 +643,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -787,33 +658,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -851,7 +707,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -869,37 +725,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -909,7 +737,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -956,7 +784,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -968,7 +796,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -976,20 +804,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1066,34 +890,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1134,7 +946,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1162,7 +974,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1174,12 +986,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-build/v0/package.json
+++ b/tasks/run-matlab-build/v0/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }

--- a/tasks/run-matlab-build/v1/package-lock.json
+++ b/tasks/run-matlab-build/v1/package-lock.json
@@ -15,6 +15,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -79,14 +114,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -94,18 +129,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -115,13 +175,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -158,6 +230,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -218,6 +304,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -292,6 +438,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -313,10 +471,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -374,6 +544,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -415,6 +594,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -422,6 +649,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -443,6 +698,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -475,6 +739,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -496,6 +772,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -505,11 +796,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -536,6 +848,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -565,6 +897,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -588,6 +953,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -678,6 +1064,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -688,6 +1089,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -720,9 +1133,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -745,6 +1158,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-build/v1/package-lock.json
+++ b/tasks/run-matlab-build/v1/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -30,7 +30,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -39,7 +39,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -99,38 +99,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -143,29 +113,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -176,7 +136,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -186,7 +146,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -233,7 +193,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -308,7 +268,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -331,7 +291,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -347,7 +307,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -356,7 +316,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -440,7 +394,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -450,30 +404,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -481,18 +414,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -546,57 +467,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -605,7 +485,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +497,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -626,7 +506,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -638,7 +518,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -653,13 +533,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -668,7 +548,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -702,7 +582,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -710,9 +590,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -741,7 +621,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -763,18 +643,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -787,33 +658,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -851,7 +707,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -869,37 +725,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -909,7 +737,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -956,7 +784,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -968,7 +796,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -976,20 +804,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1066,34 +890,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1134,7 +946,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1162,7 +974,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1174,12 +986,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-build/v1/package.json
+++ b/tasks/run-matlab-build/v1/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }

--- a/tasks/run-matlab-command/v0/package-lock.json
+++ b/tasks/run-matlab-command/v0/package-lock.json
@@ -18,6 +18,41 @@
                 "@types/uuid": "^9.0.8"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -83,14 +118,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -104,18 +139,43 @@
             "license": "MIT"
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -125,13 +185,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -168,6 +240,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -228,6 +314,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -302,6 +448,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -323,10 +481,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -384,6 +554,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -425,6 +604,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -432,6 +659,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -453,6 +708,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -485,6 +749,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -506,6 +782,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -515,11 +806,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -546,6 +858,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -575,6 +907,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -598,6 +963,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -688,6 +1074,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -698,6 +1099,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -730,9 +1143,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -755,6 +1168,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-command/v0/package-lock.json
+++ b/tasks/run-matlab-command/v0/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             },
             "devDependencies": {
@@ -20,7 +20,7 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -33,7 +33,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -42,7 +42,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -103,23 +103,23 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
+                "semver": "^5.7.2",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
             "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
             "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
@@ -138,46 +138,6 @@
             "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
             "license": "MIT"
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "^3.1.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.7.2",
-                "shelljs": "^0.10.0",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -186,7 +146,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -196,7 +156,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -243,7 +203,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -318,7 +278,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -341,7 +301,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -357,7 +317,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -366,7 +326,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -395,12 +355,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -450,7 +404,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -460,30 +414,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -491,18 +424,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -556,57 +477,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -615,7 +495,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -627,7 +507,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -636,7 +516,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -648,7 +528,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -663,13 +543,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -678,7 +558,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -712,7 +592,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -720,9 +600,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -751,7 +631,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -773,18 +653,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -797,33 +668,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -861,7 +717,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -879,37 +735,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -919,7 +747,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -966,7 +794,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -978,7 +806,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -986,20 +814,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1076,34 +900,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1144,7 +956,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1172,7 +984,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1184,12 +996,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-command/v0/package.json
+++ b/tasks/run-matlab-command/v0/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     },
     "devDependencies": {

--- a/tasks/run-matlab-command/v1/package-lock.json
+++ b/tasks/run-matlab-command/v1/package-lock.json
@@ -15,6 +15,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -79,14 +114,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -94,18 +129,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -115,13 +175,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -158,6 +230,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -218,6 +304,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -292,6 +438,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -313,10 +471,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -374,6 +544,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -415,6 +594,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -422,6 +649,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -443,6 +698,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -475,6 +739,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -496,6 +772,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -505,11 +796,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -536,6 +848,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -565,6 +897,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -588,6 +953,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -678,6 +1064,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -688,6 +1089,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -720,9 +1133,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -745,6 +1158,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-command/v1/package-lock.json
+++ b/tasks/run-matlab-command/v1/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -30,7 +30,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -39,7 +39,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -99,38 +99,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -143,29 +113,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -176,7 +136,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -186,7 +146,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -233,7 +193,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -308,7 +268,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -331,7 +291,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -347,7 +307,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -356,7 +316,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -440,7 +394,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -450,30 +404,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -481,18 +414,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -546,57 +467,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -605,7 +485,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +497,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -626,7 +506,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -638,7 +518,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -653,13 +533,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -668,7 +548,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -702,7 +582,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -710,9 +590,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -741,7 +621,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -763,18 +643,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -787,33 +658,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -851,7 +707,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -869,37 +725,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -909,7 +737,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -956,7 +784,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -968,7 +796,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -976,20 +804,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1066,34 +890,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1134,7 +946,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1162,7 +974,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1174,12 +986,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-command/v1/package.json
+++ b/tasks/run-matlab-command/v1/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }

--- a/tasks/run-matlab-tests/v0/package-lock.json
+++ b/tasks/run-matlab-tests/v0/package-lock.json
@@ -15,6 +15,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -79,14 +114,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -94,18 +129,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -115,13 +175,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -158,6 +230,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -218,6 +304,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -292,6 +438,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -313,10 +471,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -374,6 +544,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -415,6 +594,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -422,6 +649,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -443,6 +698,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -475,6 +739,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -496,6 +772,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -505,11 +796,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -536,6 +848,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -565,6 +897,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -588,6 +953,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -678,6 +1064,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -688,6 +1089,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -720,9 +1133,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -745,6 +1158,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-tests/v0/package-lock.json
+++ b/tasks/run-matlab-tests/v0/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -30,7 +30,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -39,7 +39,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -99,38 +99,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -143,29 +113,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -176,7 +136,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -186,7 +146,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -233,7 +193,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -308,7 +268,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -331,7 +291,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -347,7 +307,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -356,7 +316,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -440,7 +394,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -450,30 +404,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -481,18 +414,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -546,57 +467,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -605,7 +485,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +497,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -626,7 +506,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -638,7 +518,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -653,13 +533,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -668,7 +548,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -702,7 +582,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -710,9 +590,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -741,7 +621,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -763,18 +643,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -787,33 +658,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -851,7 +707,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -869,37 +725,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -909,7 +737,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -956,7 +784,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -968,7 +796,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -976,20 +804,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1066,34 +890,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1134,7 +946,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1162,7 +974,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1174,12 +986,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-tests/v0/package.json
+++ b/tasks/run-matlab-tests/v0/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }

--- a/tasks/run-matlab-tests/v1/package-lock.json
+++ b/tasks/run-matlab-tests/v1/package-lock.json
@@ -15,6 +15,41 @@
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -79,14 +114,14 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
-            "integrity": "sha512-yCFxJfZeNPUDCi7dbmiqVvq5lFpZdqB9kzr/wB9sZuE0RvUEhBF51gtzdR9cI5+NOsfkAVWwQJVWvdGQR5I3Wg==",
+            "version": "2.0.12",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^4.1.0",
+                "azure-pipelines-task-lib": "^5.2.7",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
@@ -94,18 +129,43 @@
             }
         },
         "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "version": "5.2.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
+                "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
-                "shelljs": "^0.8.5",
+                "shelljs": "^0.10.0",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
+            "version": "0.10.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/balanced-match": {
@@ -115,13 +175,25 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -158,6 +230,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.7",
@@ -218,6 +304,66 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -292,6 +438,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -313,10 +471,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -374,6 +544,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -415,6 +594,54 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -422,6 +649,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -443,6 +698,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -475,6 +739,18 @@
                 "sanitize-filename": "^1.6.3"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -496,6 +772,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -505,11 +796,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -536,6 +848,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -565,6 +897,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -588,6 +953,27 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -678,6 +1064,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -688,6 +1089,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -720,9 +1133,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "version": "1.13.8",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
@@ -745,6 +1158,21 @@
             "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrappy": {

--- a/tasks/run-matlab-tests/v1/package-lock.json
+++ b/tasks/run-matlab-tests/v1/package-lock.json
@@ -11,13 +11,13 @@
             "dependencies": {
                 "@types/node": "^22.7.5",
                 "@types/q": "^1.5.4",
-                "azure-pipelines-task-lib": "5.0.1-preview.0",
+                "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.7"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -30,7 +30,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -39,7 +39,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -99,38 +99,8 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.0.1-preview.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.1-preview.0.tgz",
-            "integrity": "sha512-/1R7HbRfY3ntupW3UWeU/Xoi95by8JjoHDOFL7AdwuiitIg2cKX/Hi1nbY1xNOwp+vZyMLrVo73IMYeE4pMdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "adm-zip": "^0.5.10",
-                "minimatch": "3.0.5",
-                "nodejs-file-downloader": "^4.11.1",
-                "q": "^1.5.1",
-                "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "uuid": "^3.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib": {
-            "version": "2.0.12",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/semver": "^5.3.0",
-                "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^5.2.7",
-                "semver": "^5.7.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
             "version": "5.2.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "license": "MIT",
             "dependencies": {
@@ -143,29 +113,19 @@
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
+        "node_modules/azure-pipelines-tool-lib": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+            "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+            "license": "MIT",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-            "version": "0.10.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.10.0.tgz",
-            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "execa": "^5.1.1",
-                "fast-glob": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^5.2.7",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -176,7 +136,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
@@ -186,7 +146,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -233,7 +193,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -308,7 +268,7 @@
         },
         "node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -331,7 +291,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -347,7 +307,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -356,7 +316,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -385,12 +345,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -440,7 +394,7 @@
         },
         "node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -450,30 +404,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -481,18 +414,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/gopd": {
@@ -546,57 +467,16 @@
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -605,7 +485,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +497,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -626,7 +506,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -638,7 +518,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
@@ -653,13 +533,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -668,7 +548,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -702,7 +582,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -710,9 +590,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -741,7 +621,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -763,18 +643,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -787,33 +658,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
@@ -851,7 +707,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -869,37 +725,9 @@
             ],
             "license": "MIT"
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -909,7 +737,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -956,7 +784,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -968,7 +796,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -976,20 +804,16 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
+                "execa": "^5.1.1",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/side-channel": {
@@ -1066,34 +890,22 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -1134,7 +946,7 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "license": "MIT"
         },
@@ -1162,7 +974,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://mw-npm-repository.mathworks.com:443/artifactory/api/npm/npm-repos/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -1174,12 +986,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         }
     }
 }

--- a/tasks/run-matlab-tests/v1/package.json
+++ b/tasks/run-matlab-tests/v1/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "@types/node": "^22.7.5",
         "@types/q": "^1.5.4",
-        "azure-pipelines-task-lib": "5.0.1-preview.0",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.7"
     }
 }


### PR DESCRIPTION
This change:
* Downloads matlab-batch to Agent.TempDir, which is [documented](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)  and cleared after each job, instead of the toolcache. This directory is cleared each job so there's less risk of an outdated matlab-batch
* Does not download if it already exists (if you run the task twice with different versions for example)

In addition I fixed all npm dependencies (except for mocha, which is a devDependency only with no fix currently available)